### PR TITLE
Fix concurrency settings

### DIFF
--- a/hystrix/hystrix_test.go
+++ b/hystrix/hystrix_test.go
@@ -126,6 +126,12 @@ func TestMaxConcurrent(t *testing.T) {
 	case err := <-errChan3:
 		t.Errorf(err.Error())
 	}
+	for i := 0; i < 2; i++ {
+		result := <-resultChan
+		if result != 1 {
+			t.Errorf("Concurrency level failed out the wrong call")
+		}
+	}
 }
 
 func TestOpenCircuit(t *testing.T) {
@@ -209,6 +215,6 @@ func TestCloseErrorChannel(t *testing.T) {
 		// errChan should be closed when command finishes
 		if err != nil {
 			t.Fatal("expected nil error")
-		}	
-	}	
+		}
+	}
 }

--- a/hystrix/settings.go
+++ b/hystrix/settings.go
@@ -54,6 +54,9 @@ func SetConcurrency(name string, max int) error {
 	defer config.RWMutex.Unlock()
 
 	config.Concurrency[name] = make(chan *Ticket, max)
+	for i := 0; i < max; i++ {
+		config.Concurrency[name] <- &Ticket{}
+	}
 	return nil
 }
 


### PR DESCRIPTION
There was a bug in the concurrency settings that resulted in all calls for a command to fail if the concurrency setting was changed. This fixes that bug and flushes out the test to test for that case.