### PR TITLE
Make the ThreadPool configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ hystrix.ConfigureCommand("my_command", hystrix.CommandConfig{
 	Timeout:               1000,
 	MaxConcurrentRequests: 100,
 	ErrorPercentThreshold: 25,
+	ThreadPool:            "ticketPoolName",
 })
 ```
 

--- a/hystrix/circuit.go
+++ b/hystrix/circuit.go
@@ -53,8 +53,13 @@ func Flush() {
 
 	for name, cb := range circuitBreakers {
 		cb.metrics.Reset()
-		cb.executorPool.Metrics.Reset()
 		delete(circuitBreakers, name)
+	}
+
+	// Flush pools too
+	for name, pool := range pools {
+		pool.Metrics.Reset()
+		delete(pools, name)
 	}
 }
 
@@ -65,7 +70,7 @@ func newCircuitBreaker(name string) *CircuitBreaker {
 	c := &CircuitBreaker{}
 	c.Name = name
 	c.metrics = newMetrics(name)
-	c.executorPool = newExecutorPool(settings.ThreadPool)
+	c.executorPool = getOrCreateExecutePool(settings.ThreadPool)
 	c.mutex = &sync.RWMutex{}
 
 	return c

--- a/hystrix/circuit.go
+++ b/hystrix/circuit.go
@@ -60,10 +60,12 @@ func Flush() {
 
 // newCircuitBreaker creates a CircuitBreaker with associated Health
 func newCircuitBreaker(name string) *CircuitBreaker {
+	settings := getSettings(name)
+
 	c := &CircuitBreaker{}
 	c.Name = name
 	c.metrics = newMetrics(name)
-	c.executorPool = newExecutorPool(name)
+	c.executorPool = newExecutorPool(settings.ThreadPool)
 	c.mutex = &sync.RWMutex{}
 
 	return c

--- a/hystrix/eventstream.go
+++ b/hystrix/eventstream.go
@@ -61,7 +61,9 @@ func (sh *StreamHandler) loop() {
 			circuitBreakersMutex.RLock()
 			for _, cb := range circuitBreakers {
 				sh.publishMetrics(cb)
-				sh.publishThreadPools(cb.executorPool)
+			}
+			for _, pool := range pools {
+				sh.publishThreadPools(pool)
 			}
 			circuitBreakersMutex.RUnlock()
 		case <-sh.done:

--- a/hystrix/settings.go
+++ b/hystrix/settings.go
@@ -24,6 +24,7 @@ type settings struct {
 	RequestVolumeThreshold uint64
 	SleepWindow            time.Duration
 	ErrorPercentThreshold  int
+	ThreadPool             string
 }
 
 // CommandConfig is used to tune circuit settings at runtime
@@ -33,6 +34,8 @@ type CommandConfig struct {
 	RequestVolumeThreshold int `json:"request_volume_threshold"`
 	SleepWindow            int `json:"sleep_window"`
 	ErrorPercentThreshold  int `json:"error_percent_threshold"`
+
+	ThreadPool string `json:"thread_pool"`
 }
 
 var circuitSettings map[string]*settings
@@ -80,12 +83,18 @@ func ConfigureCommand(name string, config CommandConfig) {
 		errorPercent = config.ErrorPercentThreshold
 	}
 
+	threadPool := config.ThreadPool
+	if threadPool == "" {
+		threadPool = name
+	}
+
 	circuitSettings[name] = &settings{
 		Timeout:                time.Duration(timeout) * time.Millisecond,
 		MaxConcurrentRequests:  max,
 		RequestVolumeThreshold: uint64(volume),
 		SleepWindow:            time.Duration(sleep) * time.Millisecond,
 		ErrorPercentThreshold:  errorPercent,
+		ThreadPool:             config.ThreadPool,
 	}
 }
 


### PR DESCRIPTION
Each command can now specify their used ThreadPool.

(Yes, in Go we don't really have a thread pool, but its the name from the Hystrix Dashboard).

<!---
@huboard:{"custom_state":"blocked"}
-->
