### PR TITLE
Pluggable metrics

### DIFF
--- a/hystrix/circuit.go
+++ b/hystrix/circuit.go
@@ -17,7 +17,7 @@ type CircuitBreaker struct {
 	openedOrLastTestedTime int64
 
 	executorPool *executorPool
-	metrics      *metrics
+	metrics      *metricExchange
 }
 
 var (
@@ -62,7 +62,7 @@ func Flush() {
 func newCircuitBreaker(name string) *CircuitBreaker {
 	c := &CircuitBreaker{}
 	c.Name = name
-	c.metrics = newMetrics(name)
+	c.metrics = newMetricExchange(name)
 	c.executorPool = newExecutorPool(name)
 	c.mutex = &sync.RWMutex{}
 

--- a/hystrix/eventstream.go
+++ b/hystrix/eventstream.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/afex/hystrix-go/hystrix/metric_collector"
 	"github.com/afex/hystrix-go/hystrix/rolling"
 )
 
@@ -76,7 +75,7 @@ func (sh *StreamHandler) loop() {
 func (sh *StreamHandler) publishMetrics(cb *CircuitBreaker) error {
 	now := time.Now()
 	reqCount := cb.metrics.Requests().Sum(now)
-	errCount := cb.metrics.metricCollectors[0].(*metric_collector.DefaultMetricCollector).Errors.Sum(now)
+	errCount := cb.metrics.DefaultCollector().Errors.Sum(now)
 	errPct := cb.metrics.ErrorPercent(now)
 
 	eventBytes, err := json.Marshal(&streamCmdMetric{
@@ -91,18 +90,18 @@ func (sh *StreamHandler) publishMetrics(cb *CircuitBreaker) error {
 		ErrorPct:           uint32(errPct),
 		CircuitBreakerOpen: cb.isOpen(),
 
-		RollingCountSuccess:            uint32(cb.metrics.metricCollectors[0].(*metric_collector.DefaultMetricCollector).Successes.Sum(now)),
-		RollingCountFailure:            uint32(cb.metrics.metricCollectors[0].(*metric_collector.DefaultMetricCollector).Failures.Sum(now)),
-		RollingCountThreadPoolRejected: uint32(cb.metrics.metricCollectors[0].(*metric_collector.DefaultMetricCollector).Rejects.Sum(now)),
-		RollingCountShortCircuited:     uint32(cb.metrics.metricCollectors[0].(*metric_collector.DefaultMetricCollector).ShortCircuits.Sum(now)),
-		RollingCountTimeout:            uint32(cb.metrics.metricCollectors[0].(*metric_collector.DefaultMetricCollector).Timeouts.Sum(now)),
-		RollingCountFallbackSuccess:    uint32(cb.metrics.metricCollectors[0].(*metric_collector.DefaultMetricCollector).FallbackSuccesses.Sum(now)),
-		RollingCountFallbackFailure:    uint32(cb.metrics.metricCollectors[0].(*metric_collector.DefaultMetricCollector).FallbackFailures.Sum(now)),
+		RollingCountSuccess:            uint32(cb.metrics.DefaultCollector().Successes.Sum(now)),
+		RollingCountFailure:            uint32(cb.metrics.DefaultCollector().Failures.Sum(now)),
+		RollingCountThreadPoolRejected: uint32(cb.metrics.DefaultCollector().Rejects.Sum(now)),
+		RollingCountShortCircuited:     uint32(cb.metrics.DefaultCollector().ShortCircuits.Sum(now)),
+		RollingCountTimeout:            uint32(cb.metrics.DefaultCollector().Timeouts.Sum(now)),
+		RollingCountFallbackSuccess:    uint32(cb.metrics.DefaultCollector().FallbackSuccesses.Sum(now)),
+		RollingCountFallbackFailure:    uint32(cb.metrics.DefaultCollector().FallbackFailures.Sum(now)),
 
-		LatencyTotal:       GenerateLatencyTimings(cb.metrics.metricCollectors[0].(*metric_collector.DefaultMetricCollector).TotalDuration),
-		LatencyTotalMean:   cb.metrics.metricCollectors[0].(*metric_collector.DefaultMetricCollector).TotalDuration.Mean(),
-		LatencyExecute:     GenerateLatencyTimings(cb.metrics.metricCollectors[0].(*metric_collector.DefaultMetricCollector).RunDuration),
-		LatencyExecuteMean: cb.metrics.metricCollectors[0].(*metric_collector.DefaultMetricCollector).RunDuration.Mean(),
+		LatencyTotal:       GenerateLatencyTimings(cb.metrics.DefaultCollector().TotalDuration),
+		LatencyTotalMean:   cb.metrics.DefaultCollector().TotalDuration.Mean(),
+		LatencyExecute:     GenerateLatencyTimings(cb.metrics.DefaultCollector().RunDuration),
+		LatencyExecuteMean: cb.metrics.DefaultCollector().RunDuration.Mean(),
 
 		// TODO: all hard-coded values should become configurable settings, per circuit
 

--- a/hystrix/eventstream.go
+++ b/hystrix/eventstream.go
@@ -208,7 +208,7 @@ func (sh *StreamHandler) unregister(req *http.Request) {
 	sh.mu.Unlock()
 }
 
-func GenerateLatencyTimings(r *rolling.RollingTiming) streamCmdLatency {
+func GenerateLatencyTimings(r *rolling.Timing) streamCmdLatency {
 	return streamCmdLatency{
 		Timing0:   r.Percentile(0),
 		Timing25:  r.Percentile(25),

--- a/hystrix/metric_collector/default_metric_collector.go
+++ b/hystrix/metric_collector/default_metric_collector.go
@@ -1,0 +1,87 @@
+package metric_collector
+
+import (
+	"time"
+
+	"github.com/afex/hystrix-go/hystrix/rolling"
+)
+
+type DefaultMetricCollector struct {
+	NumRequests *rolling.RollingNumber
+	Errors      *rolling.RollingNumber
+
+	Successes     *rolling.RollingNumber
+	Failures      *rolling.RollingNumber
+	Rejects       *rolling.RollingNumber
+	ShortCircuits *rolling.RollingNumber
+	Timeouts      *rolling.RollingNumber
+
+	FallbackSuccesses *rolling.RollingNumber
+	FallbackFailures  *rolling.RollingNumber
+	TotalDuration     *rolling.RollingTiming
+	RunDuration       *rolling.RollingTiming
+}
+
+func newDefaultMetricCollector(name string) MetricCollector {
+	m := &DefaultMetricCollector{}
+	m.Reset()
+	return m
+}
+
+func (d *DefaultMetricCollector) IncrementAttempts() {
+	d.NumRequests.Increment()
+}
+
+func (d *DefaultMetricCollector) IncrementErrors() {
+	d.Errors.Increment()
+}
+
+func (d *DefaultMetricCollector) IncrementSuccesses() {
+	d.Successes.Increment()
+}
+
+func (d *DefaultMetricCollector) IncrementFailures() {
+	d.Failures.Increment()
+}
+
+func (d *DefaultMetricCollector) IncrementRejects() {
+	d.Rejects.Increment()
+}
+
+func (d *DefaultMetricCollector) IncrementShortCircuits() {
+	d.ShortCircuits.Increment()
+}
+
+func (d *DefaultMetricCollector) IncrementTimeouts() {
+	d.Timeouts.Increment()
+}
+
+func (d *DefaultMetricCollector) IncrementFallbackSuccesses() {
+	d.FallbackSuccesses.Increment()
+}
+
+func (d *DefaultMetricCollector) IncrementFallbackFailures() {
+	d.FallbackFailures.Increment()
+}
+
+func (d *DefaultMetricCollector) UpdateTotalDuration(timeSinceStart time.Duration) {
+	d.TotalDuration.Add(timeSinceStart)
+}
+
+func (d *DefaultMetricCollector) UpdateRunDuration(runDuration time.Duration) {
+	d.RunDuration.Add(runDuration)
+}
+
+func (d *DefaultMetricCollector) Reset() {
+	d.NumRequests = rolling.NewRollingNumber()
+	d.Errors = rolling.NewRollingNumber()
+	d.Successes = rolling.NewRollingNumber()
+	d.Rejects = rolling.NewRollingNumber()
+	d.ShortCircuits = rolling.NewRollingNumber()
+	d.Failures = rolling.NewRollingNumber()
+	d.Timeouts = rolling.NewRollingNumber()
+	d.FallbackSuccesses = rolling.NewRollingNumber()
+	d.FallbackFailures = rolling.NewRollingNumber()
+	d.TotalDuration = rolling.NewRollingTiming()
+	d.RunDuration = rolling.NewRollingTiming()
+}

--- a/hystrix/metric_collector/default_metric_collector.go
+++ b/hystrix/metric_collector/default_metric_collector.go
@@ -1,4 +1,4 @@
-package metric_collector
+package metricCollector
 
 import (
 	"time"
@@ -6,20 +6,26 @@ import (
 	"github.com/afex/hystrix-go/hystrix/rolling"
 )
 
+// DefaultMetricCollector holds information about the circuit state.
+// This implementation of MetricCollector is the canonical source of information about the circuit.
+// It is used for for all internal hystrix operations
+// including circuit health checks and metrics sent to the hystrix dashboard.
+//
+// Metric Collectors do not need Mutexes as they are updated by circuits within a locked context.
 type DefaultMetricCollector struct {
-	NumRequests *rolling.RollingNumber
-	Errors      *rolling.RollingNumber
+	NumRequests *rolling.Number
+	Errors      *rolling.Number
 
-	Successes     *rolling.RollingNumber
-	Failures      *rolling.RollingNumber
-	Rejects       *rolling.RollingNumber
-	ShortCircuits *rolling.RollingNumber
-	Timeouts      *rolling.RollingNumber
+	Successes     *rolling.Number
+	Failures      *rolling.Number
+	Rejects       *rolling.Number
+	ShortCircuits *rolling.Number
+	Timeouts      *rolling.Number
 
-	FallbackSuccesses *rolling.RollingNumber
-	FallbackFailures  *rolling.RollingNumber
-	TotalDuration     *rolling.RollingTiming
-	RunDuration       *rolling.RollingTiming
+	FallbackSuccesses *rolling.Number
+	FallbackFailures  *rolling.Number
+	TotalDuration     *rolling.Timing
+	RunDuration       *rolling.Timing
 }
 
 func newDefaultMetricCollector(name string) MetricCollector {
@@ -28,60 +34,73 @@ func newDefaultMetricCollector(name string) MetricCollector {
 	return m
 }
 
+// IncrementAttempts increments the number of requests seen in the latest time bucket.
 func (d *DefaultMetricCollector) IncrementAttempts() {
 	d.NumRequests.Increment()
 }
 
+// IncrementErrors increments the number of errors seen in the latest time bucket.
+// Errors are any result from an attempt that is not a success.
 func (d *DefaultMetricCollector) IncrementErrors() {
 	d.Errors.Increment()
 }
 
+// IncrementSuccesses increments the number of successes seen in the latest time bucket.
 func (d *DefaultMetricCollector) IncrementSuccesses() {
 	d.Successes.Increment()
 }
 
+// IncrementFailures increments the number of failures seen in the latest time bucket.
 func (d *DefaultMetricCollector) IncrementFailures() {
 	d.Failures.Increment()
 }
 
+// IncrementRejects increments the number of rejected requests seen in the latest time bucket.
 func (d *DefaultMetricCollector) IncrementRejects() {
 	d.Rejects.Increment()
 }
 
+// IncrementShortCircuits increments the number of rejected requests seen in the latest time bucket.
 func (d *DefaultMetricCollector) IncrementShortCircuits() {
 	d.ShortCircuits.Increment()
 }
 
+// IncrementTimeouts increments the number of requests that timed out in the latest time bucket.
 func (d *DefaultMetricCollector) IncrementTimeouts() {
 	d.Timeouts.Increment()
 }
 
+// IncrementFallbackSuccesses increments the number of successful calls to the fallback function in the latest time bucket.
 func (d *DefaultMetricCollector) IncrementFallbackSuccesses() {
 	d.FallbackSuccesses.Increment()
 }
 
+// IncrementFallbackFailures increments the number of failed calls to the fallback function in the latest time bucket.
 func (d *DefaultMetricCollector) IncrementFallbackFailures() {
 	d.FallbackFailures.Increment()
 }
 
+// UpdateTotalDuration updates the total amount of time this circuit has been running.
 func (d *DefaultMetricCollector) UpdateTotalDuration(timeSinceStart time.Duration) {
 	d.TotalDuration.Add(timeSinceStart)
 }
 
+// UpdateRunDuration updates the amount of time the latest request took to complete.
 func (d *DefaultMetricCollector) UpdateRunDuration(runDuration time.Duration) {
 	d.RunDuration.Add(runDuration)
 }
 
+// Reset resets all metrics in this collector to 0.
 func (d *DefaultMetricCollector) Reset() {
-	d.NumRequests = rolling.NewRollingNumber()
-	d.Errors = rolling.NewRollingNumber()
-	d.Successes = rolling.NewRollingNumber()
-	d.Rejects = rolling.NewRollingNumber()
-	d.ShortCircuits = rolling.NewRollingNumber()
-	d.Failures = rolling.NewRollingNumber()
-	d.Timeouts = rolling.NewRollingNumber()
-	d.FallbackSuccesses = rolling.NewRollingNumber()
-	d.FallbackFailures = rolling.NewRollingNumber()
-	d.TotalDuration = rolling.NewRollingTiming()
-	d.RunDuration = rolling.NewRollingTiming()
+	d.NumRequests = rolling.NewNumber()
+	d.Errors = rolling.NewNumber()
+	d.Successes = rolling.NewNumber()
+	d.Rejects = rolling.NewNumber()
+	d.ShortCircuits = rolling.NewNumber()
+	d.Failures = rolling.NewNumber()
+	d.Timeouts = rolling.NewNumber()
+	d.FallbackSuccesses = rolling.NewNumber()
+	d.FallbackFailures = rolling.NewNumber()
+	d.TotalDuration = rolling.NewTiming()
+	d.RunDuration = rolling.NewTiming()
 }

--- a/hystrix/metric_collector/metric_collector.go
+++ b/hystrix/metric_collector/metric_collector.go
@@ -1,0 +1,64 @@
+package metric_collector
+
+import (
+	"sync"
+	"time"
+)
+
+var Registry = metricCollectorRegistryManager{
+	lock: &sync.RWMutex{},
+	registry: []func(name string) MetricCollector{
+		newDefaultMetricCollector,
+	},
+}
+
+type metricCollectorRegistryManager struct {
+	lock     *sync.RWMutex
+	registry []func(name string) MetricCollector
+}
+
+func (m *metricCollectorRegistryManager) InitializeMetricCollectors(name string) []MetricCollector {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	metrics := make([]MetricCollector, len(m.registry))
+	for i, metricCollectorInitializer := range m.registry {
+		metrics[i] = metricCollectorInitializer(name)
+	}
+	return metrics
+}
+
+func (m *metricCollectorRegistryManager) Register(initMetricCollector func(string) MetricCollector) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.registry = append(m.registry, initMetricCollector)
+}
+
+type MetricCollector interface {
+	// Always is incremented for each update.
+	IncrementAttempts()
+	// Always is incremented for each unsuccessful attempt.
+	// Attempts minus Errors will equal successes within a time range.
+	IncrementErrors()
+	// Increments the number of requests that succeed.
+	IncrementSuccesses()
+	// Increments the number of requests that fail.
+	IncrementFailures()
+	// Increments the number of requests that are rejected.
+	IncrementRejects()
+	// Increments the number of requests that short circuited due to the circuit being open.
+	IncrementShortCircuits()
+	// Increments the number of timeouts that occurred in the circuit breaker.
+	IncrementTimeouts()
+	// Increments The number of successes that occurred during the execution of the fallback function.
+	IncrementFallbackSuccesses()
+	// Increments The number of failures that occurred during the execution of the fallback function.
+	IncrementFallbackFailures()
+	// Updates the internal counter of how long we've run for.
+	UpdateTotalDuration(timeSinceStart time.Duration)
+	// Updates the internal counter of how long the last run took.
+	UpdateRunDuration(runDuration time.Duration)
+
+	Reset()
+}

--- a/hystrix/metric_collector/metric_collector.go
+++ b/hystrix/metric_collector/metric_collector.go
@@ -5,19 +5,19 @@ import (
 	"time"
 )
 
-var Registry = metricCollectorRegistryManager{
+var Registry = metricCollectorRegistry{
 	lock: &sync.RWMutex{},
 	registry: []func(name string) MetricCollector{
 		newDefaultMetricCollector,
 	},
 }
 
-type metricCollectorRegistryManager struct {
+type metricCollectorRegistry struct {
 	lock     *sync.RWMutex
 	registry []func(name string) MetricCollector
 }
 
-func (m *metricCollectorRegistryManager) InitializeMetricCollectors(name string) []MetricCollector {
+func (m *metricCollectorRegistry) InitializeMetricCollectors(name string) []MetricCollector {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 
@@ -28,7 +28,7 @@ func (m *metricCollectorRegistryManager) InitializeMetricCollectors(name string)
 	return metrics
 }
 
-func (m *metricCollectorRegistryManager) Register(initMetricCollector func(string) MetricCollector) {
+func (m *metricCollectorRegistry) Register(initMetricCollector func(string) MetricCollector) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 

--- a/hystrix/metrics.go
+++ b/hystrix/metrics.go
@@ -3,6 +3,9 @@ package hystrix
 import (
 	"sync"
 	"time"
+
+	"github.com/afex/hystrix-go/hystrix/metric_collector"
+	"github.com/afex/hystrix-go/hystrix/rolling"
 )
 
 type commandExecution struct {
@@ -11,34 +14,21 @@ type commandExecution struct {
 	RunDuration time.Duration `json:"run_duration"`
 }
 
-type metrics struct {
+type metricExchange struct {
 	Name    string
 	Updates chan *commandExecution
 	Mutex   *sync.RWMutex
 
-	numRequests *rollingNumber
-	Errors      *rollingNumber
-
-	Successes     *rollingNumber
-	Failures      *rollingNumber
-	Rejected      *rollingNumber
-	ShortCircuits *rollingNumber
-	Timeouts      *rollingNumber
-
-	FallbackSuccesses *rollingNumber
-	FallbackFailures  *rollingNumber
-
-	TotalDuration *rollingTiming
-	RunDuration   *rollingTiming
+	metricCollectors []metric_collector.MetricCollector
 }
 
-func newMetrics(name string) *metrics {
-	m := &metrics{}
+func newMetricExchange(name string) *metricExchange {
+	m := &metricExchange{}
 	m.Name = name
 
 	m.Updates = make(chan *commandExecution)
 	m.Mutex = &sync.RWMutex{}
-
+	m.metricCollectors = metric_collector.Registry.InitializeMetricCollectors(name)
 	m.Reset()
 
 	go m.Monitor()
@@ -46,85 +36,76 @@ func newMetrics(name string) *metrics {
 	return m
 }
 
-func (m *metrics) Monitor() {
+func (m *metricExchange) Monitor() {
 	for update := range m.Updates {
 		// we only grab a read lock to make sure Reset() isn't changing the numbers
 		// Increment() and Add() implement their own internal locking
 		m.Mutex.RLock()
 
-		// combined metrics
-		m.numRequests.Increment()
-		if update.Type != "success" {
-			m.Errors.Increment()
-		}
-
-		// granular metrics
-		if update.Type == "success" {
-			m.Successes.Increment()
-		}
-		if update.Type == "failure" {
-			m.Failures.Increment()
-		}
-		if update.Type == "rejected" {
-			m.Rejected.Increment()
-		}
-		if update.Type == "short-circuit" {
-			m.ShortCircuits.Increment()
-		}
-		if update.Type == "timeout" {
-			m.Timeouts.Increment()
-		}
-
-		// fallback metrics
-		if update.Type == "fallback-success" {
-			m.FallbackSuccesses.Increment()
-		}
-		if update.Type == "fallback-failure" {
-			m.FallbackFailures.Increment()
-		}
-
 		totalDuration := time.Now().Sub(update.Start)
-		m.TotalDuration.Add(totalDuration)
-		m.RunDuration.Add(update.RunDuration)
+		for _, collector := range m.metricCollectors {
+			collector.IncrementAttempts()
+			if update.Type != "success" {
+				collector.IncrementErrors()
+			}
+
+			// granular metrics
+			if update.Type == "success" {
+				collector.IncrementSuccesses()
+			}
+			if update.Type == "failure" {
+				collector.IncrementFailures()
+			}
+			if update.Type == "rejected" {
+				collector.IncrementRejects()
+			}
+			if update.Type == "short-circuit" {
+				collector.IncrementShortCircuits()
+			}
+			if update.Type == "timeout" {
+				collector.IncrementTimeouts()
+			}
+
+			// fallback metrics
+			if update.Type == "fallback-success" {
+				collector.IncrementFallbackSuccesses()
+			}
+			if update.Type == "fallback-failure" {
+				collector.IncrementFallbackFailures()
+			}
+
+			collector.UpdateTotalDuration(totalDuration)
+			collector.UpdateRunDuration(update.RunDuration)
+		}
 
 		m.Mutex.RUnlock()
 	}
 }
 
-func (m *metrics) Reset() {
+func (m *metricExchange) Reset() {
 	m.Mutex.Lock()
 	defer m.Mutex.Unlock()
 
-	m.numRequests = newRollingNumber()
-	m.Errors = newRollingNumber()
-
-	m.Successes = newRollingNumber()
-	m.Rejected = newRollingNumber()
-	m.ShortCircuits = newRollingNumber()
-	m.Failures = newRollingNumber()
-	m.Timeouts = newRollingNumber()
-
-	m.FallbackSuccesses = newRollingNumber()
-	m.FallbackFailures = newRollingNumber()
-
-	m.TotalDuration = newRollingTiming()
-	m.RunDuration = newRollingTiming()
+	for _, collector := range m.metricCollectors {
+		collector.Reset()
+	}
 }
 
-func (m *metrics) Requests() *rollingNumber {
+// This is not thread safe.
+func (m *metricExchange) Requests() *rolling.RollingNumber {
 	m.Mutex.RLock()
 	defer m.Mutex.RUnlock()
 
-	return m.numRequests
+	return m.metricCollectors[0].(*metric_collector.DefaultMetricCollector).NumRequests
 }
 
-func (m *metrics) ErrorPercent(now time.Time) int {
+func (m *metricExchange) ErrorPercent(now time.Time) int {
 	m.Mutex.RLock()
 	defer m.Mutex.RUnlock()
 
 	var errPct float64
 	reqs := m.Requests().Sum(now)
-	errs := m.Errors.Sum(now)
+	errs := m.metricCollectors[0].(*metric_collector.DefaultMetricCollector).Errors.Sum(now)
 
 	if reqs > 0 {
 		errPct = (float64(errs) / float64(reqs)) * 100
@@ -133,6 +114,6 @@ func (m *metrics) ErrorPercent(now time.Time) int {
 	return int(errPct + 0.5)
 }
 
-func (m *metrics) IsHealthy(now time.Time) bool {
+func (m *metricExchange) IsHealthy(now time.Time) bool {
 	return m.ErrorPercent(now) < getSettings(m.Name).ErrorPercentThreshold
 }

--- a/hystrix/metrics_test.go
+++ b/hystrix/metrics_test.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func metricFailingPercent(p int) *metrics {
-	m := newMetrics("")
+func metricFailingPercent(p int) *metricExchange {
+	m := newMetricExchange("")
 	for i := 0; i < 100; i++ {
 		t := "success"
 		if i < p {

--- a/hystrix/pool_metrics.go
+++ b/hystrix/pool_metrics.go
@@ -1,14 +1,18 @@
 package hystrix
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/afex/hystrix-go/hystrix/rolling"
+)
 
 type poolMetrics struct {
 	Mutex   *sync.RWMutex
 	Updates chan poolMetricsUpdate
 
 	Name              string
-	MaxActiveRequests *rollingNumber
-	Executed          *rollingNumber
+	MaxActiveRequests *rolling.RollingNumber
+	Executed          *rolling.RollingNumber
 }
 
 type poolMetricsUpdate struct {
@@ -32,8 +36,8 @@ func (m *poolMetrics) Reset() {
 	m.Mutex.Lock()
 	defer m.Mutex.Unlock()
 
-	m.MaxActiveRequests = newRollingNumber()
-	m.Executed = newRollingNumber()
+	m.MaxActiveRequests = rolling.NewRollingNumber()
+	m.Executed = rolling.NewRollingNumber()
 }
 
 func (m *poolMetrics) Monitor() {

--- a/hystrix/pool_metrics.go
+++ b/hystrix/pool_metrics.go
@@ -11,8 +11,8 @@ type poolMetrics struct {
 	Updates chan poolMetricsUpdate
 
 	Name              string
-	MaxActiveRequests *rolling.RollingNumber
-	Executed          *rolling.RollingNumber
+	MaxActiveRequests *rolling.Number
+	Executed          *rolling.Number
 }
 
 type poolMetricsUpdate struct {
@@ -36,8 +36,8 @@ func (m *poolMetrics) Reset() {
 	m.Mutex.Lock()
 	defer m.Mutex.Unlock()
 
-	m.MaxActiveRequests = rolling.NewRollingNumber()
-	m.Executed = rolling.NewRollingNumber()
+	m.MaxActiveRequests = rolling.NewNumber()
+	m.Executed = rolling.NewNumber()
 }
 
 func (m *poolMetrics) Monitor() {

--- a/hystrix/rolling/rolling.go
+++ b/hystrix/rolling/rolling.go
@@ -5,7 +5,9 @@ import (
 	"time"
 )
 
-type RollingNumber struct {
+// Number tracks a numberBucket over a bounded number of
+// time buckets. Currently the buckets are one second long and only the last 10 seconds are kept.
+type Number struct {
 	Buckets map[int64]*numberBucket
 	Mutex   *sync.RWMutex
 }
@@ -14,15 +16,16 @@ type numberBucket struct {
 	Value uint64
 }
 
-func NewRollingNumber() *RollingNumber {
-	r := &RollingNumber{
+// NewNumber initializes a RollingNumber struct.
+func NewNumber() *Number {
+	r := &Number{
 		Buckets: make(map[int64]*numberBucket),
 		Mutex:   &sync.RWMutex{},
 	}
 	return r
 }
 
-func (r *RollingNumber) getCurrentBucket() *numberBucket {
+func (r *Number) getCurrentBucket() *numberBucket {
 	r.Mutex.RLock()
 
 	now := time.Now()
@@ -40,7 +43,7 @@ func (r *RollingNumber) getCurrentBucket() *numberBucket {
 	return bucket
 }
 
-func (r *RollingNumber) removeOldBuckets() {
+func (r *Number) removeOldBuckets() {
 	now := time.Now()
 
 	for timestamp := range r.Buckets {
@@ -51,7 +54,8 @@ func (r *RollingNumber) removeOldBuckets() {
 	}
 }
 
-func (r *RollingNumber) Increment() {
+// Increment increments the number in current timeBucket.
+func (r *Number) Increment() {
 	b := r.getCurrentBucket()
 
 	r.Mutex.Lock()
@@ -61,7 +65,8 @@ func (r *RollingNumber) Increment() {
 	r.removeOldBuckets()
 }
 
-func (r *RollingNumber) UpdateMax(n int) {
+// UpdateMax updates the maximum value in the current bucket.
+func (r *Number) UpdateMax(n int) {
 	b := r.getCurrentBucket()
 
 	r.Mutex.Lock()
@@ -73,7 +78,8 @@ func (r *RollingNumber) UpdateMax(n int) {
 	r.removeOldBuckets()
 }
 
-func (r *RollingNumber) Sum(now time.Time) uint64 {
+// Sum sums the values over the buckets in the last 10 seconds.
+func (r *Number) Sum(now time.Time) uint64 {
 	sum := uint64(0)
 
 	r.Mutex.RLock()
@@ -89,7 +95,8 @@ func (r *RollingNumber) Sum(now time.Time) uint64 {
 	return sum
 }
 
-func (r *RollingNumber) Max(now time.Time) uint64 {
+// Max returns the maximum value seen in the last 10 seconds.
+func (r *Number) Max(now time.Time) uint64 {
 	var max uint64
 
 	r.Mutex.RLock()

--- a/hystrix/rolling/rolling.go
+++ b/hystrix/rolling/rolling.go
@@ -1,11 +1,11 @@
-package hystrix
+package rolling
 
 import (
 	"sync"
 	"time"
 )
 
-type rollingNumber struct {
+type RollingNumber struct {
 	Buckets map[int64]*numberBucket
 	Mutex   *sync.RWMutex
 }
@@ -14,15 +14,15 @@ type numberBucket struct {
 	Value uint64
 }
 
-func newRollingNumber() *rollingNumber {
-	r := &rollingNumber{
+func NewRollingNumber() *RollingNumber {
+	r := &RollingNumber{
 		Buckets: make(map[int64]*numberBucket),
 		Mutex:   &sync.RWMutex{},
 	}
 	return r
 }
 
-func (r *rollingNumber) getCurrentBucket() *numberBucket {
+func (r *RollingNumber) getCurrentBucket() *numberBucket {
 	r.Mutex.RLock()
 
 	now := time.Now()
@@ -40,7 +40,7 @@ func (r *rollingNumber) getCurrentBucket() *numberBucket {
 	return bucket
 }
 
-func (r *rollingNumber) removeOldBuckets() {
+func (r *RollingNumber) removeOldBuckets() {
 	now := time.Now()
 
 	for timestamp := range r.Buckets {
@@ -51,7 +51,7 @@ func (r *rollingNumber) removeOldBuckets() {
 	}
 }
 
-func (r *rollingNumber) Increment() {
+func (r *RollingNumber) Increment() {
 	b := r.getCurrentBucket()
 
 	r.Mutex.Lock()
@@ -61,7 +61,7 @@ func (r *rollingNumber) Increment() {
 	r.removeOldBuckets()
 }
 
-func (r *rollingNumber) UpdateMax(n int) {
+func (r *RollingNumber) UpdateMax(n int) {
 	b := r.getCurrentBucket()
 
 	r.Mutex.Lock()
@@ -73,7 +73,7 @@ func (r *rollingNumber) UpdateMax(n int) {
 	r.removeOldBuckets()
 }
 
-func (r *rollingNumber) Sum(now time.Time) uint64 {
+func (r *RollingNumber) Sum(now time.Time) uint64 {
 	sum := uint64(0)
 
 	r.Mutex.RLock()
@@ -89,7 +89,7 @@ func (r *rollingNumber) Sum(now time.Time) uint64 {
 	return sum
 }
 
-func (r *rollingNumber) Max(now time.Time) uint64 {
+func (r *RollingNumber) Max(now time.Time) uint64 {
 	var max uint64
 
 	r.Mutex.RLock()

--- a/hystrix/rolling/rolling_test.go
+++ b/hystrix/rolling/rolling_test.go
@@ -1,4 +1,4 @@
-package hystrix
+package rolling
 
 import (
 	"testing"
@@ -8,10 +8,9 @@ import (
 )
 
 func TestMax(t *testing.T) {
-	defer Flush()
 
 	Convey("when adding values to a rolling number", t, func() {
-		n := newRollingNumber()
+		n := NewRollingNumber()
 		for _, x := range []int{10, 11, 9} {
 			n.UpdateMax(x)
 			time.Sleep(1 * time.Second)

--- a/hystrix/rolling/rolling_test.go
+++ b/hystrix/rolling/rolling_test.go
@@ -10,7 +10,7 @@ import (
 func TestMax(t *testing.T) {
 
 	Convey("when adding values to a rolling number", t, func() {
-		n := NewRollingNumber()
+		n := NewNumber()
 		for _, x := range []int{10, 11, 9} {
 			n.UpdateMax(x)
 			time.Sleep(1 * time.Second)

--- a/hystrix/rolling/rolling_timing.go
+++ b/hystrix/rolling/rolling_timing.go
@@ -7,11 +7,14 @@ import (
 	"time"
 )
 
-type RollingTiming struct {
+// Timing maintains time Durations for each time bucket.
+// The Durations are kept in an array to allow for a variety of
+// statistics to be calculated from the source data.
+type Timing struct {
 	Buckets map[int64]*timingBucket
 	Mutex   *sync.RWMutex
 
-	CachedSortedDurations byDuration
+	CachedSortedDurations []time.Duration
 	LastCachedTime        int64
 }
 
@@ -19,8 +22,9 @@ type timingBucket struct {
 	Durations []time.Duration
 }
 
-func NewRollingTiming() *RollingTiming {
-	r := &RollingTiming{
+// NewTiming creates a RollingTiming struct.
+func NewTiming() *Timing {
+	r := &Timing{
 		Buckets: make(map[int64]*timingBucket),
 		Mutex:   &sync.RWMutex{},
 	}
@@ -33,7 +37,9 @@ func (c byDuration) Len() int           { return len(c) }
 func (c byDuration) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
 func (c byDuration) Less(i, j int) bool { return c[i] < c[j] }
 
-func (r *RollingTiming) SortedDurations() byDuration {
+// SortedDurations returns an array of time.Duration sorted from shortest
+// to longest that have occurred in the last 60 seconds.
+func (r *Timing) SortedDurations() []time.Duration {
 	r.Mutex.RLock()
 	t := r.LastCachedTime
 	r.Mutex.RUnlock()
@@ -66,7 +72,7 @@ func (r *RollingTiming) SortedDurations() byDuration {
 	return r.CachedSortedDurations
 }
 
-func (r *RollingTiming) getCurrentBucket() *timingBucket {
+func (r *Timing) getCurrentBucket() *timingBucket {
 	r.Mutex.RLock()
 	now := time.Now()
 	bucket, exists := r.Buckets[now.Unix()]
@@ -83,7 +89,7 @@ func (r *RollingTiming) getCurrentBucket() *timingBucket {
 	return bucket
 }
 
-func (r *RollingTiming) removeOldBuckets() {
+func (r *Timing) removeOldBuckets() {
 	now := time.Now()
 
 	for timestamp := range r.Buckets {
@@ -94,7 +100,8 @@ func (r *RollingTiming) removeOldBuckets() {
 	}
 }
 
-func (r *RollingTiming) Add(duration time.Duration) {
+// Add appends the time.Duration given to the current time bucket.
+func (r *Timing) Add(duration time.Duration) {
 	b := r.getCurrentBucket()
 
 	r.Mutex.Lock()
@@ -104,7 +111,8 @@ func (r *RollingTiming) Add(duration time.Duration) {
 	r.removeOldBuckets()
 }
 
-func (r *RollingTiming) Percentile(p float64) uint32 {
+// Percentile computes the percentile given with a linear interpolation.
+func (r *Timing) Percentile(p float64) uint32 {
 	sortedDurations := r.SortedDurations()
 	length := len(sortedDurations)
 	if length <= 0 {
@@ -115,7 +123,7 @@ func (r *RollingTiming) Percentile(p float64) uint32 {
 	return uint32(sortedDurations[pos].Nanoseconds() / 1000000)
 }
 
-func (r *RollingTiming) ordinal(length int, percentile float64) int64 {
+func (r *Timing) ordinal(length int, percentile float64) int64 {
 	if percentile == 0 && length > 0 {
 		return 1
 	}
@@ -123,7 +131,8 @@ func (r *RollingTiming) ordinal(length int, percentile float64) int64 {
 	return int64(math.Ceil((percentile / float64(100)) * float64(length)))
 }
 
-func (r *RollingTiming) Mean() uint32 {
+// Mean computes the average timing in the last 60 seconds.
+func (r *Timing) Mean() uint32 {
 	sortedDurations := r.SortedDurations()
 	var sum time.Duration
 	for _, d := range sortedDurations {

--- a/hystrix/rolling/rolling_timing_test.go
+++ b/hystrix/rolling/rolling_timing_test.go
@@ -1,4 +1,4 @@
-package hystrix
+package rolling
 
 import (
 	"testing"
@@ -9,9 +9,8 @@ import (
 
 func TestOrdinal(t *testing.T) {
 	Convey("given a new rolling timing", t, func() {
-		defer Flush()
 
-		r := newRollingTiming()
+		r := NewRollingTiming()
 
 		Convey("Mean() should be 0", func() {
 			So(r.Mean(), ShouldEqual, 0)

--- a/hystrix/rolling/rolling_timing_test.go
+++ b/hystrix/rolling/rolling_timing_test.go
@@ -10,7 +10,7 @@ import (
 func TestOrdinal(t *testing.T) {
 	Convey("given a new rolling timing", t, func() {
 
-		r := NewRollingTiming()
+		r := NewTiming()
 
 		Convey("Mean() should be 0", func() {
 			So(r.Mean(), ShouldEqual, 0)


### PR DESCRIPTION
Makes the metrics aggregators an interface, controlled by a metric exchange, that can be configured and specified at compile time. 

This allows users of this library to specify their own definitions and reporters of circuit status. My immediate next steps is to write a graphite aggregator.