### PR TITLE
Fixed a race condition present in GetCircuit

### DIFF
--- a/hystrix/circuit.go
+++ b/hystrix/circuit.go
@@ -38,6 +38,12 @@ func GetCircuit(name string) (*CircuitBreaker, bool, error) {
 		circuitBreakersMutex.RUnlock()
 		circuitBreakersMutex.Lock()
 		defer circuitBreakersMutex.Unlock()
+		// because we released the rlock before we obtained the exclusive lock,
+		// we need to double check that some other thread didn't beat us to
+		// creation.
+		if cb, ok := circuitBreakers[name]; ok {
+			return cb, false, nil
+		}
 		circuitBreakers[name] = newCircuitBreaker(name)
 	} else {
 		defer circuitBreakersMutex.RUnlock()


### PR DESCRIPTION
Fixed a race condition present in GetCircuit that can be seen when running tests with the -race flag or otherwise in high contention and CPU load.

Basically, you just need to check again after the exclusive lock is obtained in case some other waiting thread got the exclusive lock before you for the same name.  You can see the added unit test fail when running with the -race flag (this is threadsafe, but still unexpected behavior).  

<!---
@huboard:{"order":14.0,"milestone_order":26,"custom_state":""}
-->
