### PR TITLE
Reduced the number of times a lock is acquired.

### DIFF
--- a/hystrix/rolling.go
+++ b/hystrix/rolling.go
@@ -23,50 +23,43 @@ func newRollingNumber() *rollingNumber {
 }
 
 func (r *rollingNumber) getCurrentBucket() *numberBucket {
-	r.Mutex.RLock()
+	now := time.Now().Unix()
+	var bucket *numberBucket
+	var ok bool
 
-	now := time.Now()
-	bucket, exists := r.Buckets[now.Unix()]
-	if !exists {
-		r.Mutex.RUnlock()
-		r.Mutex.Lock()
-		defer r.Mutex.Unlock()
-
-		r.Buckets[now.Unix()] = &numberBucket{}
-		bucket = r.Buckets[now.Unix()]
-	} else {
-		defer r.Mutex.RUnlock()
+	if bucket, ok = r.Buckets[now]; !ok {
+		bucket = &numberBucket{}
+		r.Buckets[now] = bucket
 	}
+
 	return bucket
 }
 
 func (r *rollingNumber) removeOldBuckets() {
-	now := time.Now()
+	now := time.Now().Unix() - 10
 
 	for timestamp := range r.Buckets {
 		// TODO: configurable rolling window
-		if timestamp <= now.Unix()-10 {
+		if timestamp <= now {
 			delete(r.Buckets, timestamp)
 		}
 	}
 }
 
 func (r *rollingNumber) Increment() {
-	b := r.getCurrentBucket()
-
 	r.Mutex.Lock()
 	defer r.Mutex.Unlock()
 
+	b := r.getCurrentBucket()
 	b.Value++
 	r.removeOldBuckets()
 }
 
 func (r *rollingNumber) UpdateMax(n int) {
-	b := r.getCurrentBucket()
-
 	r.Mutex.Lock()
 	defer r.Mutex.Unlock()
 
+	b := r.getCurrentBucket()
 	if uint64(n) > b.Value {
 		b.Value = uint64(n)
 	}

--- a/hystrix/rolling_test.go
+++ b/hystrix/rolling_test.go
@@ -22,3 +22,23 @@ func TestMax(t *testing.T) {
 		})
 	})
 }
+
+func BenchmarkRollingNumberIncrement(b *testing.B) {
+	n := newRollingNumber()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		n.Increment()
+	}
+}
+
+func BenchmarkRollingNumberUpdateMax(b *testing.B) {
+	n := newRollingNumber()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		n.UpdateMax(i)
+	}
+}


### PR DESCRIPTION
There was a race condition in getCurrentBucket which is removed.  The codepaths that went down the getCurrentBucket path would sometimes acquire the same lock as many as 3 times.  Given that increment and set max would eventually have to acquire an exclusive lock, I just acquire that lock off the bat.  Added some benchmarks to state the case:
Current master:
BenchmarkRollingNumberIncrement-8	10000000	       204 ns/op
BenchmarkRollingNumberUpdateMax-8	10000000	       209 ns/op

This branch:
BenchmarkRollingNumberIncrement-8	10000000	       147 ns/op
BenchmarkRollingNumberUpdateMax-8	20000000	       149 ns/op

<!---
@huboard:{"order":29.0,"milestone_order":27,"custom_state":"blocked"}
-->
