### PR TITLE
Make hystrix Default values writeable

### DIFF
--- a/hystrix/settings.go
+++ b/hystrix/settings.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-const (
+var (
 	// DefaultTimeout is how long to wait for command to complete, in milliseconds
 	DefaultTimeout = 1000
 	// DefaultMaxConcurrent is how many commands of the same type can run at the same time


### PR DESCRIPTION
This allows an app to override the default settings when it starts up.