### PR TITLE
Implement a badRequests counter

### DIFF
--- a/hystrix/eventstream.go
+++ b/hystrix/eventstream.go
@@ -95,6 +95,7 @@ func (sh *StreamHandler) publishMetrics(cb *CircuitBreaker) error {
 		RollingCountThreadPoolRejected: uint32(cb.metrics.DefaultCollector().Rejects.Sum(now)),
 		RollingCountShortCircuited:     uint32(cb.metrics.DefaultCollector().ShortCircuits.Sum(now)),
 		RollingCountTimeout:            uint32(cb.metrics.DefaultCollector().Timeouts.Sum(now)),
+		RollingCountBadRequests:        uint32(cb.metrics.DefaultCollector().BadRequests.Sum(now)),
 		RollingCountFallbackSuccess:    uint32(cb.metrics.DefaultCollector().FallbackSuccesses.Sum(now)),
 		RollingCountFallbackFailure:    uint32(cb.metrics.DefaultCollector().FallbackFailures.Sum(now)),
 
@@ -247,6 +248,7 @@ type streamCmdMetric struct {
 	RollingCountSuccess            uint32 `json:"rollingCountSuccess"`
 	RollingCountThreadPoolRejected uint32 `json:"rollingCountThreadPoolRejected"`
 	RollingCountTimeout            uint32 `json:"rollingCountTimeout"`
+	RollingCountBadRequests        uint32 `json:"rollingCountBadRequests"`
 
 	CurrentConcurrentExecutionCount uint32 `json:"currentConcurrentExecutionCount"`
 

--- a/hystrix/metric_collector/default_metric_collector.go
+++ b/hystrix/metric_collector/default_metric_collector.go
@@ -21,6 +21,7 @@ type DefaultMetricCollector struct {
 	Rejects       *rolling.Number
 	ShortCircuits *rolling.Number
 	Timeouts      *rolling.Number
+	BadRequests   *rolling.Number
 
 	FallbackSuccesses *rolling.Number
 	FallbackFailures  *rolling.Number
@@ -70,6 +71,11 @@ func (d *DefaultMetricCollector) IncrementTimeouts() {
 	d.Timeouts.Increment()
 }
 
+// IncrementBadRequests increments the number of bad requests seen in the latest time bucket.
+func (d *DefaultMetricCollector) IncrementBadRequests() {
+	d.BadRequests.Increment()
+}
+
 // IncrementFallbackSuccesses increments the number of successful calls to the fallback function in the latest time bucket.
 func (d *DefaultMetricCollector) IncrementFallbackSuccesses() {
 	d.FallbackSuccesses.Increment()
@@ -99,6 +105,7 @@ func (d *DefaultMetricCollector) Reset() {
 	d.ShortCircuits = rolling.NewNumber()
 	d.Failures = rolling.NewNumber()
 	d.Timeouts = rolling.NewNumber()
+	d.BadRequests = rolling.NewNumber()
 	d.FallbackSuccesses = rolling.NewNumber()
 	d.FallbackFailures = rolling.NewNumber()
 	d.TotalDuration = rolling.NewTiming()

--- a/hystrix/metric_collector/metric_collector.go
+++ b/hystrix/metric_collector/metric_collector.go
@@ -59,6 +59,8 @@ type MetricCollector interface {
 	IncrementShortCircuits()
 	// IncrementTimeouts increments the number of timeouts that occurred in the circuit breaker.
 	IncrementTimeouts()
+	// IncrementBadRequests increments the number of bad requests seen in the latest time bucket.
+	IncrementBadRequests()
 	// IncrementFallbackSuccesses increments the number of successes that occurred during the execution of the fallback function.
 	IncrementFallbackSuccesses()
 	// IncrementFallbackFailures increments the number of failures that occurred during the execution of the fallback function.

--- a/hystrix/metrics.go
+++ b/hystrix/metrics.go
@@ -76,6 +76,9 @@ func (m *metricExchange) Monitor() {
 			if update.Type == "timeout" {
 				collector.IncrementTimeouts()
 			}
+			if update.Type == "bad-request" {
+				collector.IncrementBadRequests()
+			}
 
 			// fallback metrics
 			if update.Type == "fallback-success" {

--- a/plugins/graphite_aggregator.go
+++ b/plugins/graphite_aggregator.go
@@ -28,6 +28,7 @@ type GraphiteCollector struct {
 	rejectsPrefix           string
 	shortCircuitsPrefix     string
 	timeoutsPrefix          string
+	badRequestsPrefix       string
 	fallbackSuccessesPrefix string
 	fallbackFailuresPrefix  string
 	totalDurationPrefix     string
@@ -65,6 +66,7 @@ func NewGraphiteCollector(name string) metricCollector.MetricCollector {
 		rejectsPrefix:           name + ".rejects",
 		shortCircuitsPrefix:     name + ".shortCircuits",
 		timeoutsPrefix:          name + ".timeouts",
+		badRequestsPrefix:       name + ".badRequests",
 		fallbackSuccessesPrefix: name + ".fallbackSuccesses",
 		fallbackFailuresPrefix:  name + ".fallbackFailures",
 		totalDurationPrefix:     name + ".totalDuration",
@@ -132,6 +134,12 @@ func (g *GraphiteCollector) IncrementShortCircuits() {
 // This registers as a counter in the graphite collector.
 func (g *GraphiteCollector) IncrementTimeouts() {
 	g.incrementCounterMetric(g.timeoutsPrefix)
+}
+
+// IncrementBadRequests increments the number of bad requests that occurred in the circuit breaker.
+// This registers as a counter in the graphite collector.
+func (g *GraphiteCollector) IncrementBadRequests() {
+	g.incrementCounterMetric(g.badRequestsPrefix)
 }
 
 // IncrementFallbackSuccesses increments the number of successes that occurred during the execution of the fallback function.

--- a/plugins/statsd_collector.go
+++ b/plugins/statsd_collector.go
@@ -24,6 +24,7 @@ type StatsdCollector struct {
 	rejectsPrefix           string
 	shortCircuitsPrefix     string
 	timeoutsPrefix          string
+	badRequestsPrefix       string
 	fallbackSuccessesPrefix string
 	fallbackFailuresPrefix  string
 	totalDurationPrefix     string
@@ -77,6 +78,7 @@ func (s *StatsdCollectorClient) NewStatsdCollector(name string) metricCollector.
 		rejectsPrefix:           name + ".rejects",
 		shortCircuitsPrefix:     name + ".shortCircuits",
 		timeoutsPrefix:          name + ".timeouts",
+		badRequestsPrefix:       name + ".timeouts",
 		fallbackSuccessesPrefix: name + ".fallbackSuccesses",
 		fallbackFailuresPrefix:  name + ".fallbackFailures",
 		totalDurationPrefix:     name + ".totalDuration",
@@ -150,6 +152,12 @@ func (g *StatsdCollector) IncrementShortCircuits() {
 // IncrementTimeouts increments the number of timeouts that occurred in the circuit breaker.
 // This registers as a counter in the Statsd collector.
 func (g *StatsdCollector) IncrementTimeouts() {
+	g.incrementCounterMetric(g.timeoutsPrefix)
+}
+
+// IncrementBadRequests increments the number of bad requests that occurred in the circuit breaker.
+// This registers as a counter in the Statsd collector.
+func (g *StatsdCollector) IncrementBadRequests() {
 	g.incrementCounterMetric(g.timeoutsPrefix)
 }
 


### PR DESCRIPTION
I just tried to use the Hystrix Dashboard and it broke because of a missing `rollingCountBadRequests` property.

This adds that counter, and the required stuff around it.

What I'm unsure about here is how a bad request should be tracked, it's not very well documented in Hystrix itself (...or, I just couldn't find the docs). I found this issue: https://github.com/Netflix/Hystrix/issues/186 that discussed bad requests in relationship to the dash.

BREAKING CHANGE: This is a breaking change for anyone implementing custom collectors as the collector interface has a new function `IncrementBadRequests()`.
