### PR TITLE
Fix default metric collector data race

### DIFF
--- a/hystrix/eventstream.go
+++ b/hystrix/eventstream.go
@@ -75,7 +75,7 @@ func (sh *StreamHandler) loop() {
 func (sh *StreamHandler) publishMetrics(cb *CircuitBreaker) error {
 	now := time.Now()
 	reqCount := cb.metrics.Requests().Sum(now)
-	errCount := cb.metrics.DefaultCollector().Errors.Sum(now)
+	errCount := cb.metrics.DefaultCollector().Errors().Sum(now)
 	errPct := cb.metrics.ErrorPercent(now)
 
 	eventBytes, err := json.Marshal(&streamCmdMetric{
@@ -90,18 +90,18 @@ func (sh *StreamHandler) publishMetrics(cb *CircuitBreaker) error {
 		ErrorPct:           uint32(errPct),
 		CircuitBreakerOpen: cb.IsOpen(),
 
-		RollingCountSuccess:            uint32(cb.metrics.DefaultCollector().Successes.Sum(now)),
-		RollingCountFailure:            uint32(cb.metrics.DefaultCollector().Failures.Sum(now)),
-		RollingCountThreadPoolRejected: uint32(cb.metrics.DefaultCollector().Rejects.Sum(now)),
-		RollingCountShortCircuited:     uint32(cb.metrics.DefaultCollector().ShortCircuits.Sum(now)),
-		RollingCountTimeout:            uint32(cb.metrics.DefaultCollector().Timeouts.Sum(now)),
-		RollingCountFallbackSuccess:    uint32(cb.metrics.DefaultCollector().FallbackSuccesses.Sum(now)),
-		RollingCountFallbackFailure:    uint32(cb.metrics.DefaultCollector().FallbackFailures.Sum(now)),
+		RollingCountSuccess:            uint32(cb.metrics.DefaultCollector().Successes().Sum(now)),
+		RollingCountFailure:            uint32(cb.metrics.DefaultCollector().Failures().Sum(now)),
+		RollingCountThreadPoolRejected: uint32(cb.metrics.DefaultCollector().Rejects().Sum(now)),
+		RollingCountShortCircuited:     uint32(cb.metrics.DefaultCollector().ShortCircuits().Sum(now)),
+		RollingCountTimeout:            uint32(cb.metrics.DefaultCollector().Timeouts().Sum(now)),
+		RollingCountFallbackSuccess:    uint32(cb.metrics.DefaultCollector().FallbackSuccesses().Sum(now)),
+		RollingCountFallbackFailure:    uint32(cb.metrics.DefaultCollector().FallbackFailures().Sum(now)),
 
-		LatencyTotal:       GenerateLatencyTimings(cb.metrics.DefaultCollector().TotalDuration),
-		LatencyTotalMean:   cb.metrics.DefaultCollector().TotalDuration.Mean(),
-		LatencyExecute:     GenerateLatencyTimings(cb.metrics.DefaultCollector().RunDuration),
-		LatencyExecuteMean: cb.metrics.DefaultCollector().RunDuration.Mean(),
+		LatencyTotal:       GenerateLatencyTimings(cb.metrics.DefaultCollector().TotalDuration()),
+		LatencyTotalMean:   cb.metrics.DefaultCollector().TotalDuration().Mean(),
+		LatencyExecute:     GenerateLatencyTimings(cb.metrics.DefaultCollector().RunDuration()),
+		LatencyExecuteMean: cb.metrics.DefaultCollector().RunDuration().Mean(),
 
 		// TODO: all hard-coded values should become configurable settings, per circuit
 

--- a/hystrix/metric_collector/default_metric_collector.go
+++ b/hystrix/metric_collector/default_metric_collector.go
@@ -1,6 +1,7 @@
 package metricCollector
 
 import (
+	"sync"
 	"time"
 
 	"github.com/afex/hystrix-go/hystrix/rolling"
@@ -13,94 +14,199 @@ import (
 //
 // Metric Collectors do not need Mutexes as they are updated by circuits within a locked context.
 type DefaultMetricCollector struct {
-	NumRequests *rolling.Number
-	Errors      *rolling.Number
+	mutex *sync.RWMutex
 
-	Successes     *rolling.Number
-	Failures      *rolling.Number
-	Rejects       *rolling.Number
-	ShortCircuits *rolling.Number
-	Timeouts      *rolling.Number
+	numRequests *rolling.Number
+	errors      *rolling.Number
 
-	FallbackSuccesses *rolling.Number
-	FallbackFailures  *rolling.Number
-	TotalDuration     *rolling.Timing
-	RunDuration       *rolling.Timing
+	successes     *rolling.Number
+	failures      *rolling.Number
+	rejects       *rolling.Number
+	shortCircuits *rolling.Number
+	timeouts      *rolling.Number
+
+	fallbackSuccesses *rolling.Number
+	fallbackFailures  *rolling.Number
+	totalDuration     *rolling.Timing
+	runDuration       *rolling.Timing
 }
 
 func newDefaultMetricCollector(name string) MetricCollector {
 	m := &DefaultMetricCollector{}
+	m.mutex = &sync.RWMutex{}
 	m.Reset()
 	return m
 }
 
+// NumRequests returns the rolling number of requests
+func (d *DefaultMetricCollector) NumRequests() *rolling.Number {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	return d.numRequests
+}
+
+// Errors returns the rolling number of errors
+func (d *DefaultMetricCollector) Errors() *rolling.Number {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	return d.errors
+}
+
+// Successes returns the rolling number of successes
+func (d *DefaultMetricCollector) Successes() *rolling.Number {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	return d.successes
+}
+
+// Failures returns the rolling number of failures
+func (d *DefaultMetricCollector) Failures() *rolling.Number {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	return d.failures
+}
+
+// Rejects returns the rolling number of rejects
+func (d *DefaultMetricCollector) Rejects() *rolling.Number {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	return d.rejects
+}
+
+// ShortCircuits returns the rolling number of short circuits
+func (d *DefaultMetricCollector) ShortCircuits() *rolling.Number {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	return d.shortCircuits
+}
+
+// Timeouts returns the rolling number of timeouts
+func (d *DefaultMetricCollector) Timeouts() *rolling.Number {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	return d.timeouts
+}
+
+// FallbackSuccesses returns the rolling number of fallback successes
+func (d *DefaultMetricCollector) FallbackSuccesses() *rolling.Number {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	return d.fallbackSuccesses
+}
+
+// FallbackFailures returns the rolling number of fallback failures
+func (d *DefaultMetricCollector) FallbackFailures() *rolling.Number {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	return d.fallbackFailures
+}
+
+// TotalDuration returns the rolling total duration
+func (d *DefaultMetricCollector) TotalDuration() *rolling.Timing {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	return d.totalDuration
+}
+
+// RunDuration returns the rolling run duration
+func (d *DefaultMetricCollector) RunDuration() *rolling.Timing {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	return d.runDuration
+}
+
 // IncrementAttempts increments the number of requests seen in the latest time bucket.
 func (d *DefaultMetricCollector) IncrementAttempts() {
-	d.NumRequests.Increment(1)
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	d.numRequests.Increment(1)
 }
 
 // IncrementErrors increments the number of errors seen in the latest time bucket.
 // Errors are any result from an attempt that is not a success.
 func (d *DefaultMetricCollector) IncrementErrors() {
-	d.Errors.Increment(1)
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	d.errors.Increment(1)
 }
 
 // IncrementSuccesses increments the number of successes seen in the latest time bucket.
 func (d *DefaultMetricCollector) IncrementSuccesses() {
-	d.Successes.Increment(1)
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	d.successes.Increment(1)
 }
 
 // IncrementFailures increments the number of failures seen in the latest time bucket.
 func (d *DefaultMetricCollector) IncrementFailures() {
-	d.Failures.Increment(1)
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	d.failures.Increment(1)
 }
 
 // IncrementRejects increments the number of rejected requests seen in the latest time bucket.
 func (d *DefaultMetricCollector) IncrementRejects() {
-	d.Rejects.Increment(1)
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	d.rejects.Increment(1)
 }
 
 // IncrementShortCircuits increments the number of rejected requests seen in the latest time bucket.
 func (d *DefaultMetricCollector) IncrementShortCircuits() {
-	d.ShortCircuits.Increment(1)
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	d.shortCircuits.Increment(1)
 }
 
 // IncrementTimeouts increments the number of requests that timed out in the latest time bucket.
 func (d *DefaultMetricCollector) IncrementTimeouts() {
-	d.Timeouts.Increment(1)
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	d.timeouts.Increment(1)
 }
 
 // IncrementFallbackSuccesses increments the number of successful calls to the fallback function in the latest time bucket.
 func (d *DefaultMetricCollector) IncrementFallbackSuccesses() {
-	d.FallbackSuccesses.Increment(1)
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	d.fallbackSuccesses.Increment(1)
 }
 
 // IncrementFallbackFailures increments the number of failed calls to the fallback function in the latest time bucket.
 func (d *DefaultMetricCollector) IncrementFallbackFailures() {
-	d.FallbackFailures.Increment(1)
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	d.fallbackFailures.Increment(1)
 }
 
 // UpdateTotalDuration updates the total amount of time this circuit has been running.
 func (d *DefaultMetricCollector) UpdateTotalDuration(timeSinceStart time.Duration) {
-	d.TotalDuration.Add(timeSinceStart)
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	d.totalDuration.Add(timeSinceStart)
 }
 
 // UpdateRunDuration updates the amount of time the latest request took to complete.
 func (d *DefaultMetricCollector) UpdateRunDuration(runDuration time.Duration) {
-	d.RunDuration.Add(runDuration)
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	d.runDuration.Add(runDuration)
 }
 
 // Reset resets all metrics in this collector to 0.
 func (d *DefaultMetricCollector) Reset() {
-	d.NumRequests = rolling.NewNumber()
-	d.Errors = rolling.NewNumber()
-	d.Successes = rolling.NewNumber()
-	d.Rejects = rolling.NewNumber()
-	d.ShortCircuits = rolling.NewNumber()
-	d.Failures = rolling.NewNumber()
-	d.Timeouts = rolling.NewNumber()
-	d.FallbackSuccesses = rolling.NewNumber()
-	d.FallbackFailures = rolling.NewNumber()
-	d.TotalDuration = rolling.NewTiming()
-	d.RunDuration = rolling.NewTiming()
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+
+	d.numRequests = rolling.NewNumber()
+	d.errors = rolling.NewNumber()
+	d.successes = rolling.NewNumber()
+	d.rejects = rolling.NewNumber()
+	d.shortCircuits = rolling.NewNumber()
+	d.failures = rolling.NewNumber()
+	d.timeouts = rolling.NewNumber()
+	d.fallbackSuccesses = rolling.NewNumber()
+	d.fallbackFailures = rolling.NewNumber()
+	d.totalDuration = rolling.NewTiming()
+	d.runDuration = rolling.NewTiming()
 }

--- a/hystrix/metrics.go
+++ b/hystrix/metrics.go
@@ -106,7 +106,7 @@ func (m *metricExchange) Requests() *rolling.Number {
 	m.Mutex.RLock()
 	defer m.Mutex.RUnlock()
 
-	return m.DefaultCollector().NumRequests
+	return m.DefaultCollector().NumRequests()
 }
 
 func (m *metricExchange) ErrorPercent(now time.Time) int {
@@ -115,7 +115,7 @@ func (m *metricExchange) ErrorPercent(now time.Time) int {
 
 	var errPct float64
 	reqs := m.Requests().Sum(now)
-	errs := m.DefaultCollector().Errors.Sum(now)
+	errs := m.DefaultCollector().Errors().Sum(now)
 
 	if reqs > 0 {
 		errPct = (float64(errs) / float64(reqs)) * 100


### PR DESCRIPTION
Fix for this race:
```
WARNING: DATA RACE
Write by goroutine 3233:
  github.com/afex/hystrix-go/hystrix/metric_collector.(*DefaultMetricCollector).Reset()
      /build/Godeps/_workspace/src/github.com/afex/hystrix-go/hystrix/metric_collector/default_metric_collector.go:105 +0xe76
  github.com/afex/hystrix-go/hystrix.(*metricExchange).Reset()
      /build/Godeps/_workspace/src/github.com/afex/hystrix-go/hystrix/metrics.go:101 +0x11a
  github.com/afex/hystrix-go/hystrix.(*CircuitBreaker).setClose()
      /build/Godeps/_workspace/src/github.com/afex/hystrix-go/hystrix/circuit.go:154 +0x1a6
  github.com/afex/hystrix-go/hystrix.(*CircuitBreaker).ReportEvent()
      /build/Godeps/_workspace/src/github.com/afex/hystrix-go/hystrix/circuit.go:160 +0xa9
  github.com/afex/hystrix-go/hystrix.func·002()
      /build/Godeps/_workspace/src/github.com/afex/hystrix-go/hystrix/hystrix.go:106 +0x779

Previous read by goroutine 33:
  github.com/afex/hystrix-go/hystrix.(*StreamHandler).publishMetrics()
      /build/Godeps/_workspace/src/github.com/afex/hystrix-go/hystrix/eventstream.go:104 +0x766
  github.com/afex/hystrix-go/hystrix.(*StreamHandler).loop()
      /build/Godeps/_workspace/src/github.com/afex/hystrix-go/hystrix/eventstream.go:65 +0x1a0
```