### PR TITLE
Load openedOrLastTestedTime atomically

### DIFF
--- a/hystrix/circuit.go
+++ b/hystrix/circuit.go
@@ -123,8 +123,9 @@ func (circuit *CircuitBreaker) allowSingleTest() bool {
 	defer circuit.mutex.RUnlock()
 
 	now := time.Now().UnixNano()
-	if circuit.open && now > circuit.openedOrLastTestedTime+getSettings(circuit.Name).SleepWindow.Nanoseconds() {
-		swapped := atomic.CompareAndSwapInt64(&circuit.openedOrLastTestedTime, circuit.openedOrLastTestedTime, now)
+	openedOrLastTestedTime := atomic.LoadInt64(&circuit.openedOrLastTestedTime)
+	if circuit.open && now > openedOrLastTestedTime+getSettings(circuit.Name).SleepWindow.Nanoseconds() {
+		swapped := atomic.CompareAndSwapInt64(&circuit.openedOrLastTestedTime, openedOrLastTestedTime, now)
 		if swapped {
 			log.Printf("hystrix-go: allowing single test to possibly close circuit %v", circuit.Name)
 		}


### PR DESCRIPTION
Fix for this data race:
```
WARNING: DATA RACE
Write by goroutine 3294:
  sync/atomic.CompareAndSwapInt64()
      /usr/local/go/src/runtime/race_amd64.s:286 +0xc
  github.com/afex/hystrix-go/hystrix.(*CircuitBreaker).allowSingleTest()
      /build/Godeps/_workspace/src/github.com/afex/hystrix-go/hystrix/circuit.go:127 +0x1dd
  github.com/afex/hystrix-go/hystrix.(*CircuitBreaker).AllowRequest()
      /build/Godeps/_workspace/src/github.com/afex/hystrix-go/hystrix/circuit.go:118 +0x4d
  github.com/afex/hystrix-go/hystrix.func·002()
      /build/Godeps/_workspace/src/github.com/afex/hystrix-go/hystrix/hystrix.go:58 +0x157

Previous read by goroutine 730:
  github.com/afex/hystrix-go/hystrix.(*CircuitBreaker).allowSingleTest()
      /build/Godeps/_workspace/src/github.com/afex/hystrix-go/hystrix/circuit.go:126 +0x17a
  github.com/afex/hystrix-go/hystrix.(*CircuitBreaker).AllowRequest()
      /build/Godeps/_workspace/src/github.com/afex/hystrix-go/hystrix/circuit.go:118 +0x4d
  github.com/afex/hystrix-go/hystrix.func·002()
      /build/Godeps/_workspace/src/github.com/afex/hystrix-go/hystrix/hystrix.go:58 +0x157
```