### PR TITLE
Prevent double fallback

### DIFF
--- a/hystrix/hystrix.go
+++ b/hystrix/hystrix.go
@@ -62,6 +62,13 @@ func Go(name string, run runFunc, fallback fallbackFunc) chan error {
 		// Rejecting new executions allows backends to recover, and the circuit will allow
 		// new traffic when it feels a healthly state has returned.
 		if !circuit.AllowRequest() {
+			stopMutex.Lock()
+			defer stopMutex.Unlock()
+			if stop {
+				return
+			}
+			stop = true
+			
 			circuit.ReportEvent("short-circuit", start, 0)
 			err := tryFallback(fallbackOnce, circuit, start, 0, fallback, ErrCircuitOpen)
 			if err != nil {

--- a/hystrix/hystrix_test.go
+++ b/hystrix/hystrix_test.go
@@ -262,7 +262,7 @@ func TestSlowFallbackOpenCircuit(t *testing.T) {
 				out <- struct{}{}
 				return nil
 			})
-			
+
 			Convey("the fallback only fires for the short-circuit, not both", func() {
 				time.Sleep(250 * time.Millisecond)
 				So(len(out), ShouldEqual, 1)

--- a/hystrix/hystrix_test.go
+++ b/hystrix/hystrix_test.go
@@ -266,6 +266,11 @@ func TestSlowFallbackOpenCircuit(t *testing.T) {
 			Convey("the fallback only fires for the short-circuit, not both", func() {
 				time.Sleep(250 * time.Millisecond)
 				So(len(out), ShouldEqual, 1)
+
+				Convey("and a timeout event is not recorded", func() {
+					So(cb.metrics.DefaultCollector().ShortCircuits().Sum(time.Now()), ShouldEqual, 1)
+					So(cb.metrics.DefaultCollector().Timeouts().Sum(time.Now()), ShouldEqual, 0)
+				})
 			})
 		})
 	})

--- a/plugins/statsd_collector.go
+++ b/plugins/statsd_collector.go
@@ -47,7 +47,7 @@ type StatsdCollectorConfig struct {
 //
 // Users should ensure to call Close() on the client.
 func InitializeStatsdCollector(config *StatsdCollectorConfig) (*StatsdCollectorClient, error) {
-	c, err := statsd.NewBufferedClient(config.StatsdAddr, config.Prefix, 1 * time.Second, 512)
+	c, err := statsd.NewBufferedClient(config.StatsdAddr, config.Prefix, 1*time.Second, 512)
 	if err != nil {
 		log.Printf("Could not initiale buffered client: %s. Falling back to a Noop Statsd client", err)
 		c, _ = statsd.NewNoopClient()


### PR DESCRIPTION
a slow fallback (or performance regression in stats reporting) could cause a command to timeout while actively processing a previous error (such as the circuit being open).

this PR prevents this case, ensuring only the first encountered error type triggers the fallback and is recorded for metrics.