### PR TITLE
Added support for CloseNotify in the event stream

### DIFF
--- a/hystrix/eventstream_test.go
+++ b/hystrix/eventstream_test.go
@@ -232,8 +232,9 @@ func TestClientCancelEventStream(t *testing.T) {
 			afterFirstRead.Wait()
 
 			Convey("it should be registered", func() {
+				server.StreamHandler.mu.RLock()
 				So(len(server.StreamHandler.requests), ShouldEqual, 1)
-
+				server.StreamHandler.mu.RUnlock()
 				Convey("after client disconnects", func() {
 					// let the request be cancelled and the body closed
 					close(wait)
@@ -241,7 +242,9 @@ func TestClientCancelEventStream(t *testing.T) {
 					time.Sleep(2000 * time.Millisecond)
 					Convey("it should be detected as disconnected and de-registered", func() {
 						//confirm we have 0 clients
+						server.StreamHandler.mu.RLock()
 						So(len(server.StreamHandler.requests), ShouldEqual, 0)
+						server.StreamHandler.mu.RUnlock()
 					})
 				})
 			})

--- a/hystrix/eventstream_test.go
+++ b/hystrix/eventstream_test.go
@@ -3,7 +3,6 @@ package hystrix
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -203,7 +202,6 @@ func TestClientCancelEventStream(t *testing.T) {
 				buf := []byte{0}
 				res, err := client.Do(req)
 				if err != nil {
-					log.Fatal(err)
 					t.Fatal(err)
 				}
 				defer res.Body.Close()
@@ -218,7 +216,6 @@ func TestClientCancelEventStream(t *testing.T) {
 						//read something
 						_, err = res.Body.Read(buf)
 						if err != nil {
-							log.Fatal(err)
 							t.Fatal(err)
 						}
 						if afr != nil {


### PR DESCRIPTION
StreamHandlers were hanging around after clients disconnected and creating noise.  I suppose with enough hits to ServeHTTP it could have eventually impacted legitimate clients via port exhaustion, etc.