### PR TITLE
make ToggleForceOpen public

### DIFF
--- a/hystrix/circuit.go
+++ b/hystrix/circuit.go
@@ -76,9 +76,9 @@ func newCircuitBreaker(name string) *CircuitBreaker {
 	return c
 }
 
-// toggleForceOpen allows manually causing the fallback logic for all instances
+// ToggleForceOpen allows manually causing the fallback logic for all instances
 // of a given command.
-func (circuit *CircuitBreaker) toggleForceOpen(toggle bool) error {
+func (circuit *CircuitBreaker) ToggleForceOpen(toggle bool) error {
 	circuit, _, err := GetCircuit(circuit.Name)
 	if err != nil {
 		return err

--- a/hystrix/hystrix_test.go
+++ b/hystrix/hystrix_test.go
@@ -161,7 +161,7 @@ func TestForceOpenCircuit(t *testing.T) {
 		cb, _, err := GetCircuit("")
 		So(err, ShouldEqual, nil)
 
-		cb.toggleForceOpen(true)
+		cb.ToggleForceOpen(true)
 
 		errChan := Go("", func() error {
 			return nil


### PR DESCRIPTION
There a nice function that allow user to "manually" open a circuit but it is not accessible. Internally it is only called by a dedicated test.
Just changing the visibility of that function so that user out of the package can use it.