### PR TITLE
Add NoOpCircuitBreaker

### DIFF
--- a/hystrix/circuit_test.go
+++ b/hystrix/circuit_test.go
@@ -12,13 +12,16 @@ func TestGetCircuit(t *testing.T) {
 	defer Flush()
 
 	Convey("when calling GetCircuit", t, func() {
+		var createdCircuit CircuitBreakerInterface
 		var created bool
 		var err error
-		_, created, err = GetCircuit("foo")
+		createdCircuit, created, err = GetCircuit("foo")
+		circuit := newCircuitBreaker("bar")
 
-		Convey("once, the circuit should be created", func() {
+		Convey("once, the circuit should be created, and should be same type as CircuitBreaker", func() {
 			So(err, ShouldBeNil)
 			So(created, ShouldEqual, true)
+			So(createdCircuit, ShouldHaveSameTypeAs, circuit)
 		})
 
 		Convey("twice, the circuit should be reused", func() {
@@ -63,6 +66,76 @@ func TestMultithreadedGetCircuit(t *testing.T) {
 
 		Convey("should be threadsafe", func() {
 			So(numCreates, ShouldEqual, int32(1))
+		})
+	})
+}
+
+func TestGetNoOpCircuit(t *testing.T) {
+	defer Flush()
+
+	Convey("given a command config setting to disable circuit breaker", t, func() {
+		ConfigureCommand("foo", CommandConfig{CircuitBreakerDisabled: true})
+
+		Convey("when calling GetCircuit", func() {
+			var createdCircuit CircuitBreakerInterface
+			var created bool
+			var err error
+			createdCircuit, created, err = GetCircuit("foo")
+			noOpCircuit := newNoOpCircuitBreaker("bar")
+
+			Convey("once, the circuit should be created, and should be same type as NoOpCircuitBreaker", func() {
+				So(err, ShouldBeNil)
+				So(created, ShouldEqual, true)
+				So(createdCircuit, ShouldHaveSameTypeAs, noOpCircuit)
+			})
+
+			Convey("twice, the circuit should be reused", func() {
+				_, created, err = GetCircuit("foo")
+				So(err, ShouldBeNil)
+				So(created, ShouldEqual, false)
+			})
+		})
+	})
+}
+
+func TestMultithreadedGetNoOpCircuit(t *testing.T) {
+	defer Flush()
+
+	Convey("given a command config setting to disable circuit breaker", t, func() {
+		ConfigureCommand("foo", CommandConfig{CircuitBreakerDisabled: true})
+
+		Convey("calling GetCircuit", func() {
+			numThreads := 100
+			var numCreates int32
+			var numRunningRoutines int32
+			var startingLine sync.WaitGroup
+			var finishLine sync.WaitGroup
+			startingLine.Add(1)
+			finishLine.Add(numThreads)
+
+			for i := 0; i < numThreads; i++ {
+				go func() {
+					if atomic.AddInt32(&numRunningRoutines, 1) == int32(numThreads) {
+						startingLine.Done()
+					} else {
+						startingLine.Wait()
+					}
+
+					_, created, _ := GetCircuit("foo")
+
+					if created {
+						atomic.AddInt32(&numCreates, 1)
+					}
+
+					finishLine.Done()
+				}()
+			}
+
+			finishLine.Wait()
+
+			Convey("should be threadsafe", func() {
+				So(numCreates, ShouldEqual, int32(1))
+			})
 		})
 	})
 }

--- a/hystrix/eventstream_test.go
+++ b/hystrix/eventstream_test.go
@@ -3,6 +3,7 @@ package hystrix
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -264,6 +265,141 @@ func TestThreadPoolStream(t *testing.T) {
 
 			Convey("the pool size should be 10", func() {
 				So(metric.CurrentPoolSize, ShouldEqual, 10)
+			})
+		})
+	})
+}
+
+func TestNoOpEventStream(t *testing.T) {
+	Convey("given a command config setting to disable circuit breaker", t, func() {
+		ConfigureCommand("eventstream", CommandConfig{CircuitBreakerDisabled: true})
+		ConfigureCommand("errorpercent", CommandConfig{CircuitBreakerDisabled: true})
+
+		Convey("given a running event stream", func() {
+			server := startTestServer()
+			defer server.stopTestServer()
+
+			Convey("after 2 successful commands", func() {
+				sleepingCommand(t, "eventstream", 1*time.Millisecond)
+				sleepingCommand(t, "eventstream", 1*time.Millisecond)
+
+				Convey("request count should be 2", func() {
+					event := grabFirstCommandFromStream(t, server.URL)
+
+					So(event.Name, ShouldEqual, "eventstream")
+					So(int(event.RequestCount), ShouldEqual, 2)
+				})
+			})
+
+			Convey("after 1 successful command and 2 unsuccessful commands", func() {
+				sleepingCommand(t, "errorpercent", 1*time.Millisecond)
+				failingCommand(t, "errorpercent", 1*time.Millisecond)
+				failingCommand(t, "errorpercent", 1*time.Millisecond)
+
+				Convey("the error precentage should be 67", func() {
+					metric := grabFirstCommandFromStream(t, server.URL)
+
+					So(metric.ErrorPct, ShouldEqual, 67)
+				})
+			})
+		})
+	})
+}
+
+func TestNoOpClientCancelEventStream(t *testing.T) {
+	Convey("given a command config setting to disable circuit breaker", t, func() {
+		ConfigureCommand("eventstream", CommandConfig{CircuitBreakerDisabled: true})
+
+		Convey("given a running event stream", func() {
+			server := startTestServer()
+			defer server.stopTestServer()
+
+			sleepingCommand(t, "eventstream", 1*time.Millisecond)
+
+			Convey("after a client connects", func() {
+				req, err := http.NewRequest("GET", server.URL, nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				// use a transport so we can cancel the stream when we're done - in 1.5 this is much easier
+				tr := &http.Transport{}
+				client := &http.Client{Transport: tr}
+				wait := make(chan struct{})
+				afterFirstRead := &sync.WaitGroup{}
+				afterFirstRead.Add(1)
+
+				go func() {
+					afr := afterFirstRead
+					buf := []byte{0}
+					res, err := client.Do(req)
+					if err != nil {
+						t.Fatal(err)
+					}
+					defer res.Body.Close()
+
+					for {
+						select {
+						case <-wait:
+							//wait for master goroutine to break us out
+							tr.CancelRequest(req)
+							return
+						default:
+							//read something
+							_, err = res.Body.Read(buf)
+							if err != nil {
+								t.Fatal(err)
+							}
+							if afr != nil {
+								afr.Done()
+								afr = nil
+							}
+						}
+					}
+				}()
+				// need to make sure our request has round-tripped to the server
+				afterFirstRead.Wait()
+
+				Convey("it should be registered", func() {
+					server.StreamHandler.mu.RLock()
+					So(len(server.StreamHandler.requests), ShouldEqual, 1)
+					server.StreamHandler.mu.RUnlock()
+					Convey("after client disconnects", func() {
+						// let the request be cancelled and the body closed
+						close(wait)
+						// wait for the server to clean up
+						time.Sleep(2000 * time.Millisecond)
+						Convey("it should be detected as disconnected and de-registered", func() {
+							//confirm we have 0 clients
+							server.StreamHandler.mu.RLock()
+							So(len(server.StreamHandler.requests), ShouldEqual, 0)
+							server.StreamHandler.mu.RUnlock()
+						})
+					})
+				})
+			})
+		})
+	})
+}
+
+func TestNoOpThreadPoolStream(t *testing.T) {
+	Convey("given a command config setting to disable circuit breaker", t, func() {
+		ConfigureCommand("threadpool", CommandConfig{CircuitBreakerDisabled: true})
+
+		Convey("given a running event stream", func() {
+			server := startTestServer()
+			defer server.stopTestServer()
+
+			Convey("after a successful command", func() {
+				sleepingCommand(t, "threadpool", 1*time.Millisecond)
+				metric := grabFirstThreadPoolFromStream(t, server.URL)
+
+				Convey("the rolling count of executions should increment", func() {
+					So(metric.RollingCountThreadsExecuted, ShouldEqual, 1)
+				})
+
+				Convey("the pool size should be math.MaxInt32 2147483647", func() {
+					So(metric.CurrentPoolSize, ShouldEqual, math.MaxInt32)
+				})
 			})
 		})
 	})

--- a/hystrix/hystrix.go
+++ b/hystrix/hystrix.go
@@ -29,7 +29,7 @@ type command struct {
 	errChan      chan error
 	finished     chan bool
 	fallbackOnce *sync.Once
-	circuit      *CircuitBreaker
+	circuit      CircuitBreakerInterface
 	run          runFunc
 	fallback     fallbackFunc
 	runDuration  time.Duration
@@ -90,7 +90,7 @@ func Go(name string, run runFunc, fallback fallbackFunc) chan error {
 		// shed load which accumulates due to the increasing ratio of active commands to incoming requests.
 		cmd.Lock()
 		select {
-		case cmd.ticket = <-circuit.executorPool.Tickets:
+		case cmd.ticket = <-cmd.circuit.ExecutorPool().Ticket():
 			cmd.Unlock()
 		default:
 			cmd.Unlock()
@@ -116,7 +116,7 @@ func Go(name string, run runFunc, fallback fallbackFunc) chan error {
 	go func() {
 		defer func() {
 			cmd.Lock()
-			cmd.circuit.executorPool.Return(cmd.ticket)
+			cmd.circuit.ExecutorPool().Return(cmd.ticket)
 			cmd.Unlock()
 
 			cmd.circuit.ReportEvent(cmd.events, cmd.start, cmd.runDuration)

--- a/hystrix/pool.go
+++ b/hystrix/pool.go
@@ -1,24 +1,114 @@
 package hystrix
 
+import (
+	"math"
+	"sync/atomic"
+)
+
+// ExecutorPoolInterface is the interface of executor pool
+type ExecutorPoolInterface interface {
+	// Name returns pool name
+	Name() string
+	// Ticket returns a chan, client can get ticket from this chan
+	Ticket() <-chan *struct{}
+	// Return returns back the ticket client previously get from pool
+	Return(ticket *struct{})
+	// ActiveCount returns the active count of `clients` in the pool
+	ActiveCount() int
+	// Max returns the maximum tickets number in pool
+	Max() int
+	// Metrics returns metrics object associated with this pool
+	Metrics() *poolMetrics
+}
+
+// noOpExecutorPool have infinite tickets, it will not block client's requests
+type noOpExecutorPool struct {
+	name    string
+	count   int32
+	metrics *poolMetrics
+}
+
+// newNoOpExecutorPool creates noOpExecutorPool
+func newNoOpExecutorPool(name string) *noOpExecutorPool {
+	p := &noOpExecutorPool{}
+	p.name = name
+	p.count = 0
+	p.metrics = newPoolMetrics(name)
+	return p
+}
+
+func (p *noOpExecutorPool) Name() string {
+	return p.name
+}
+
+// noOpTicket is the ticket instance noOpExecutorPool gives to clients
+var noOpTicket = &struct{}{}
+
+// Ticket will always return a buffered chan with 1 noOpTicket in it
+// It will close the chan so no more tickets being send to the chan
+func (p *noOpExecutorPool) Ticket() <-chan *struct{} {
+	atomic.AddInt32(&p.count, 1)
+
+	ticket := make(chan *struct{}, 1)
+	ticket <- noOpTicket
+	// close means no more values will be send to this chan
+	// it's safe to receive from close chan
+	close(ticket)
+	return ticket
+}
+
+// Return will update noOpExecutorPool's metrics
+func (p *noOpExecutorPool) Return(ticket *struct{}) {
+	if ticket == nil {
+		return
+	}
+
+	p.metrics.Updates <- poolMetricsUpdate{
+		activeCount: p.ActiveCount(),
+	}
+	atomic.AddInt32(&p.count, -1)
+}
+
+func (p *noOpExecutorPool) Metrics() *poolMetrics {
+	return p.metrics
+}
+
+func (p *noOpExecutorPool) ActiveCount() int {
+	return int(p.count)
+}
+
+// Max of noOpExecutorPool will return MaxInt32
+func (p *noOpExecutorPool) Max() int {
+	return math.MaxInt32
+}
+
 type executorPool struct {
-	Name    string
-	Metrics *poolMetrics
-	Max     int
-	Tickets chan *struct{}
+	name    string
+	metrics *poolMetrics
+	max     int
+	tickets chan *struct{}
 }
 
 func newExecutorPool(name string) *executorPool {
 	p := &executorPool{}
-	p.Name = name
-	p.Metrics = newPoolMetrics(name)
-	p.Max = getSettings(name).MaxConcurrentRequests
+	p.name = name
+	p.metrics = newPoolMetrics(name)
+	p.max = getSettings(name).MaxConcurrentRequests
 
-	p.Tickets = make(chan *struct{}, p.Max)
-	for i := 0; i < p.Max; i++ {
-		p.Tickets <- &struct{}{}
+	p.tickets = make(chan *struct{}, p.max)
+	for i := 0; i < p.max; i++ {
+		p.tickets <- &struct{}{}
 	}
 
 	return p
+}
+
+func (p *executorPool) Name() string {
+	return p.name
+}
+
+func (p *executorPool) Ticket() <-chan *struct{} {
+	return p.tickets
 }
 
 func (p *executorPool) Return(ticket *struct{}) {
@@ -26,12 +116,20 @@ func (p *executorPool) Return(ticket *struct{}) {
 		return
 	}
 
-	p.Metrics.Updates <- poolMetricsUpdate{
+	p.metrics.Updates <- poolMetricsUpdate{
 		activeCount: p.ActiveCount(),
 	}
-	p.Tickets <- ticket
+	p.tickets <- ticket
 }
 
 func (p *executorPool) ActiveCount() int {
-	return p.Max - len(p.Tickets)
+	return p.max - len(p.tickets)
+}
+
+func (p *executorPool) Max() int {
+	return p.max
+}
+
+func (p *executorPool) Metrics() *poolMetrics {
+	return p.metrics
 }

--- a/hystrix/pool_test.go
+++ b/hystrix/pool_test.go
@@ -12,11 +12,11 @@ func TestReturn(t *testing.T) {
 
 	Convey("when returning a ticket to the pool", t, func() {
 		pool := newExecutorPool("pool")
-		ticket := <-pool.Tickets
+		ticket := <-pool.Ticket()
 		pool.Return(ticket)
 		time.Sleep(1 * time.Millisecond)
 		Convey("total executed requests should increment", func() {
-			So(pool.Metrics.Executed.Sum(time.Now()), ShouldEqual, 1)
+			So(pool.Metrics().Executed.Sum(time.Now()), ShouldEqual, 1)
 		})
 	})
 }
@@ -26,9 +26,9 @@ func TestActiveCount(t *testing.T) {
 
 	Convey("when 3 tickets are pulled", t, func() {
 		pool := newExecutorPool("pool")
-		<-pool.Tickets
-		<-pool.Tickets
-		ticket := <-pool.Tickets
+		<-pool.Ticket()
+		<-pool.Ticket()
+		ticket := <-pool.Ticket()
 
 		Convey("ActiveCount() should be 3", func() {
 			So(pool.ActiveCount(), ShouldEqual, 3)
@@ -39,8 +39,70 @@ func TestActiveCount(t *testing.T) {
 
 			Convey("max active requests should be 3", func() {
 				time.Sleep(1 * time.Millisecond) // allow poolMetrics to process channel
-				So(pool.Metrics.MaxActiveRequests.Max(time.Now()), ShouldEqual, 3)
+				So(pool.Metrics().MaxActiveRequests.Max(time.Now()), ShouldEqual, 3)
 			})
 		})
 	})
+}
+
+func TestNoOpReturn(t *testing.T) {
+	defer Flush()
+
+	Convey("when returning a ticket to the pool", t, func() {
+		pool := newNoOpExecutorPool("pool")
+		ticket := <-pool.Ticket()
+		pool.Return(ticket)
+		time.Sleep(1 * time.Millisecond)
+		Convey("total executed requests should increment", func() {
+			So(pool.Metrics().Executed.Sum(time.Now()), ShouldEqual, 1)
+		})
+	})
+}
+
+func TestNoOpActiveCount(t *testing.T) {
+	defer Flush()
+
+	Convey("when 3 tickets are pulled", t, func() {
+		pool := newNoOpExecutorPool("pool")
+		<-pool.Ticket()
+		<-pool.Ticket()
+		ticket := <-pool.Ticket()
+
+		Convey("ActiveCount() should be 3", func() {
+			So(pool.ActiveCount(), ShouldEqual, 3)
+		})
+
+		Convey("and one is returned", func() {
+			pool.Return(ticket)
+
+			Convey("max active requests should be 3", func() {
+				time.Sleep(1 * time.Millisecond) // allow poolMetrics to process channel
+				So(pool.Metrics().MaxActiveRequests.Max(time.Now()), ShouldEqual, 3)
+			})
+		})
+	})
+}
+
+func BenchmarkTickets(B *testing.B) {
+	pool := newExecutorPool("BenchmarkTickets")
+	run := func() {
+		ticket := <-pool.Ticket()
+		pool.Return(ticket)
+	}
+
+	for i := 0; i < B.N; i++ {
+		run()
+	}
+}
+
+func BenchmarkNoOpTickets(B *testing.B) {
+	pool := newNoOpExecutorPool("BenchmarkNoOpTickets")
+	run := func() {
+		ticket := <-pool.Ticket()
+		pool.Return(ticket)
+	}
+
+	for i := 0; i < B.N; i++ {
+		run()
+	}
 }

--- a/hystrix/settings_test.go
+++ b/hystrix/settings_test.go
@@ -46,3 +46,23 @@ func TestSleepWindowDefault(t *testing.T) {
 		})
 	})
 }
+
+func TestCircuitBreakerDisabledDefault(t *testing.T) {
+	Convey("given default settings", t, func() {
+		ConfigureCommand("", CommandConfig{})
+
+		Convey("the circuit breaker disabled should be false", func() {
+			So(getSettings("").CircuitBreakerDisabled, ShouldEqual, false)
+		})
+	})
+}
+
+func TestConfigCircuitBreakerDisabled(t *testing.T) {
+	Convey("given a command configured to circuit breaker disabled true", t, func() {
+		ConfigureCommand("", CommandConfig{CircuitBreakerDisabled: true})
+
+		Convey("the circuit breaker disabled should be true", func() {
+			So(getSettings("").CircuitBreakerDisabled, ShouldEqual, true)
+		})
+	})
+}


### PR DESCRIPTION
Change-Id: I81cff81983ff099217825466b24a72bf63c37665

In this PR, I try to add a NoOpCircuitBreaker same as here [HystrixCircuitBreaker.java](https://github.com/Netflix/Hystrix/blob/master/hystrix-core/src/main/java/com/netflix/hystrix/HystrixCircuitBreaker.java#L220-L237). It enables user to disable CircuitBreaker but still use the metrics and Dashboard feature, which is needed for new users like me.

The general logic is as follows:

1. Add a `CircuitBreakerDisabled` setting so user can disable circuit. Default value is false for backward compatibility.
2. If user config `CircuitBreakerDisabled` as true, `GetCircuit` will return a `NoOpCircuitBreaker` with a `noOpExecutorPool`.

More infos can be find in comments.


The test coverage is 93.2% and I had test the logic in real code logic.
The benchmark of original and NoOp circuit is nearly the same, benchmark of noOpExecutorPool is worse than original executorPool, I think it may because I always return a new buffered chan with 1 element in it.

Please help review the code, looking forward to hear advises from you. Thanks!