### PR TITLE
don't allow circuit to open while recording metrics

### DIFF
--- a/hystrix/circuit.go
+++ b/hystrix/circuit.go
@@ -170,8 +170,8 @@ func (circuit *CircuitBreaker) ReportEvent(eventTypes []string, start time.Time,
 		return fmt.Errorf("no event types sent for metrics")
 	}
 
-	if eventTypes[0] == "success" && circuit.IsOpen() {
-		circuit.setClose()
+	if eventTypes[0] == "success" && circuit.open {
+		circuit.setClose()	
 	}
 
 	select {

--- a/hystrix/circuit.go
+++ b/hystrix/circuit.go
@@ -171,7 +171,7 @@ func (circuit *CircuitBreaker) ReportEvent(eventTypes []string, start time.Time,
 	}
 
 	if eventTypes[0] == "success" && circuit.open {
-		circuit.setClose()	
+		circuit.setClose()
 	}
 
 	select {

--- a/scripts/vagrant.sh
+++ b/scripts/vagrant.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-wget -q https://storage.googleapis.com/golang/go1.5rc1.linux-amd64.tar.gz
-tar -C /usr/local -xzf go1.5rc1.linux-amd64.tar.gz
+wget -q https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz
+tar -C /usr/local -xzf go1.6.2.linux-amd64.tar.gz
 
 apt-get update
 apt-get -y install git mercurial apache2-utils


### PR DESCRIPTION
this change brings hystrix-go more inline with the java version which doesn't provide a way for the circuit to open as a side effect of marking success.