### PR TITLE
Dynamically re-sizable ticketpool 

### DIFF
--- a/hystrix/circuit.go
+++ b/hystrix/circuit.go
@@ -186,3 +186,9 @@ func (circuit *CircuitBreaker) ReportEvent(eventTypes []string, start time.Time,
 
 	return nil
 }
+
+func (circuit *CircuitBreaker) ResizePool(n int) {
+	circuit.mutex.Lock()
+	circuit.executorPool.resize(n)
+	circuit.mutex.Unlock()
+}

--- a/hystrix/hystrix_test.go
+++ b/hystrix/hystrix_test.go
@@ -118,11 +118,9 @@ func TestTimeoutEmptyFallback(t *testing.T) {
 }
 
 func TestMaxConcurrent(t *testing.T) {
-	Convey("if a command has max concurrency set to 2\n", t, func() {//Remove \n
+	Convey("if a command has max concurrency set to 2", t, func() {
 		defer Flush()
-		fmt.Printf("what is this?\n")
 		ConfigureCommand("", CommandConfig{MaxConcurrentRequests: 2})
-		println("Checkpoint 2")
 		resultChan := make(chan int)
 
 		run := func() error {

--- a/hystrix/hystrix_test.go
+++ b/hystrix/hystrix_test.go
@@ -118,9 +118,11 @@ func TestTimeoutEmptyFallback(t *testing.T) {
 }
 
 func TestMaxConcurrent(t *testing.T) {
-	Convey("if a command has max concurrency set to 2", t, func() {
+	Convey("if a command has max concurrency set to 2\n", t, func() {//Remove \n
 		defer Flush()
+		fmt.Printf("what is this?\n")
 		ConfigureCommand("", CommandConfig{MaxConcurrentRequests: 2})
+		println("Checkpoint 2")
 		resultChan := make(chan int)
 
 		run := func() error {

--- a/hystrix/pool.go
+++ b/hystrix/pool.go
@@ -5,6 +5,7 @@ type executorPool struct {
 	Metrics *poolMetrics
 	Max     int
 	Tickets chan *struct{}
+	excessive chan *struct{}
 }
 
 func newExecutorPool(name string) *executorPool {
@@ -14,6 +15,7 @@ func newExecutorPool(name string) *executorPool {
 	p.Max = getSettings(name).MaxConcurrentRequests
 
 	p.Tickets = make(chan *struct{}, p.Max)
+	p.excessive = make(chan *struct{}, 0)
 	for i := 0; i < p.Max; i++ {
 		p.Tickets <- &struct{}{}
 	}
@@ -29,9 +31,41 @@ func (p *executorPool) Return(ticket *struct{}) {
 	p.Metrics.Updates <- poolMetricsUpdate{
 		activeCount: p.ActiveCount(),
 	}
-	p.Tickets <- ticket
+	select {
+	case _ = <-p.excessive:
+		return
+	default:
+		p.Tickets <- ticket
+	}
 }
 
 func (p *executorPool) ActiveCount() int {
-	return p.Max - len(p.Tickets)
+	return p.Max - len(p.Tickets) + len(p.excessive)
+}
+
+func (p *executorPool) resize(n int) {
+	if n < 1 {
+		// dont resize to something < 1
+		return
+	}
+
+	active := p.ActiveCount()
+
+	alloc_cnt := n - active
+	if alloc_cnt < 0 {
+		excessive := alloc_cnt * -1
+		// a channel that serves as a counter with excessive tickets
+		p.excessive = make(chan *struct{}, excessive)
+		for i := 0; i < excessive; i++ {
+			p.excessive <- &struct{}{}
+		}
+
+	}
+
+	p.Max = n
+	p.Tickets = make(chan *struct{}, p.Max)
+
+	for i := 0; i < alloc_cnt; i++ {
+		p.Tickets <- &struct{}{}
+	}
 }

--- a/hystrix/settings.go
+++ b/hystrix/settings.go
@@ -63,6 +63,15 @@ func ConfigureCommand(name string, config CommandConfig) {
 	max := DefaultMaxConcurrent
 	if config.MaxConcurrentRequests != 0 {
 		max = config.MaxConcurrentRequests
+		defer func(){
+			settingsMutex.Unlock()
+			c, created, err := GetCircuit(name)
+			settingsMutex.Lock()
+			if err != nil || created {
+			} else {
+				c.ResizePool(max)
+			}
+		}()
 	}
 
 	volume := DefaultVolumeThreshold


### PR DESCRIPTION
Currently changing max concurrency in the settings by using Configure will not have any effect on the actual ticketpool. This means that a microservice will have to be redeployed if the max concurrency needs to be changed.