### PR TITLE
Adding active count and maximum active count into plugin metrics

### DIFF
--- a/hystrix/circuit.go
+++ b/hystrix/circuit.go
@@ -179,6 +179,9 @@ func (circuit *CircuitBreaker) ReportEvent(eventTypes []string, start time.Time,
 		Types:       eventTypes,
 		Start:       start,
 		RunDuration: runDuration,
+
+		CurrentActiveCount:        circuit.executorPool.ActiveCount(),
+		CurrentMaximumActiveCount: int(circuit.executorPool.Metrics.MaxActiveRequests.Max(time.Now())),
 	}:
 	default:
 		return CircuitError{Message: fmt.Sprintf("metrics channel (%v) is at capacity", circuit.Name)}

--- a/hystrix/circuit.go
+++ b/hystrix/circuit.go
@@ -17,8 +17,8 @@ type CircuitBreaker struct {
 	mutex                  *sync.RWMutex
 	openedOrLastTestedTime int64
 
-	executorPool *executorPool
-	metrics      *metricExchange
+	executorPool           *executorPool
+	metrics                *metricExchange
 }
 
 var (
@@ -125,7 +125,7 @@ func (circuit *CircuitBreaker) allowSingleTest() bool {
 
 	now := time.Now().UnixNano()
 	openedOrLastTestedTime := atomic.LoadInt64(&circuit.openedOrLastTestedTime)
-	if circuit.open && now > openedOrLastTestedTime+getSettings(circuit.Name).SleepWindow.Nanoseconds() {
+	if circuit.open && now > openedOrLastTestedTime + getSettings(circuit.Name).SleepWindow.Nanoseconds() {
 		swapped := atomic.CompareAndSwapInt64(&circuit.openedOrLastTestedTime, openedOrLastTestedTime, now)
 		if swapped {
 			log.Printf("hystrix-go: allowing single test to possibly close circuit %v", circuit.Name)

--- a/hystrix/eventstream.go
+++ b/hystrix/eventstream.go
@@ -58,7 +58,7 @@ func (sh *StreamHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	for {
 		select {
 		case <-notify:
-			// client is gone
+		// client is gone
 			return
 		case event := <-events:
 			_, err := rw.Write(event)
@@ -238,37 +238,37 @@ func generateLatencyTimings(r *rolling.Timing) streamCmdLatency {
 }
 
 type streamCmdMetric struct {
-	Type           string `json:"type"`
-	Name           string `json:"name"`
-	Group          string `json:"group"`
-	Time           int64  `json:"currentTime"`
-	ReportingHosts uint32 `json:"reportingHosts"`
+	Type                                             string `json:"type"`
+	Name                                             string `json:"name"`
+	Group                                            string `json:"group"`
+	Time                                             int64  `json:"currentTime"`
+	ReportingHosts                                   uint32 `json:"reportingHosts"`
 
 	// Health
-	RequestCount       uint32 `json:"requestCount"`
-	ErrorCount         uint32 `json:"errorCount"`
-	ErrorPct           uint32 `json:"errorPercentage"`
-	CircuitBreakerOpen bool   `json:"isCircuitBreakerOpen"`
+	RequestCount                                     uint32 `json:"requestCount"`
+	ErrorCount                                       uint32 `json:"errorCount"`
+	ErrorPct                                         uint32 `json:"errorPercentage"`
+	CircuitBreakerOpen                               bool   `json:"isCircuitBreakerOpen"`
 
-	RollingCountCollapsedRequests  uint32 `json:"rollingCountCollapsedRequests"`
-	RollingCountExceptionsThrown   uint32 `json:"rollingCountExceptionsThrown"`
-	RollingCountFailure            uint32 `json:"rollingCountFailure"`
-	RollingCountFallbackFailure    uint32 `json:"rollingCountFallbackFailure"`
-	RollingCountFallbackRejection  uint32 `json:"rollingCountFallbackRejection"`
-	RollingCountFallbackSuccess    uint32 `json:"rollingCountFallbackSuccess"`
-	RollingCountResponsesFromCache uint32 `json:"rollingCountResponsesFromCache"`
-	RollingCountSemaphoreRejected  uint32 `json:"rollingCountSemaphoreRejected"`
-	RollingCountShortCircuited     uint32 `json:"rollingCountShortCircuited"`
-	RollingCountSuccess            uint32 `json:"rollingCountSuccess"`
-	RollingCountThreadPoolRejected uint32 `json:"rollingCountThreadPoolRejected"`
-	RollingCountTimeout            uint32 `json:"rollingCountTimeout"`
+	RollingCountCollapsedRequests                    uint32 `json:"rollingCountCollapsedRequests"`
+	RollingCountExceptionsThrown                     uint32 `json:"rollingCountExceptionsThrown"`
+	RollingCountFailure                              uint32 `json:"rollingCountFailure"`
+	RollingCountFallbackFailure                      uint32 `json:"rollingCountFallbackFailure"`
+	RollingCountFallbackRejection                    uint32 `json:"rollingCountFallbackRejection"`
+	RollingCountFallbackSuccess                      uint32 `json:"rollingCountFallbackSuccess"`
+	RollingCountResponsesFromCache                   uint32 `json:"rollingCountResponsesFromCache"`
+	RollingCountSemaphoreRejected                    uint32 `json:"rollingCountSemaphoreRejected"`
+	RollingCountShortCircuited                       uint32 `json:"rollingCountShortCircuited"`
+	RollingCountSuccess                              uint32 `json:"rollingCountSuccess"`
+	RollingCountThreadPoolRejected                   uint32 `json:"rollingCountThreadPoolRejected"`
+	RollingCountTimeout                              uint32 `json:"rollingCountTimeout"`
 
-	CurrentConcurrentExecutionCount uint32 `json:"currentConcurrentExecutionCount"`
+	CurrentConcurrentExecutionCount                  uint32 `json:"currentConcurrentExecutionCount"`
 
-	LatencyExecuteMean uint32           `json:"latencyExecute_mean"`
-	LatencyExecute     streamCmdLatency `json:"latencyExecute"`
-	LatencyTotalMean   uint32           `json:"latencyTotal_mean"`
-	LatencyTotal       streamCmdLatency `json:"latencyTotal"`
+	LatencyExecuteMean                               uint32           `json:"latencyExecute_mean"`
+	LatencyExecute                                   streamCmdLatency `json:"latencyExecute"`
+	LatencyTotalMean                                 uint32           `json:"latencyTotal_mean"`
+	LatencyTotal                                     streamCmdLatency `json:"latencyTotal"`
 
 	// Properties
 	CircuitBreakerRequestVolumeThreshold             uint32 `json:"propertyValue_circuitBreakerRequestVolumeThreshold"`
@@ -301,18 +301,18 @@ type streamCmdLatency struct {
 }
 
 type streamThreadPoolMetric struct {
-	Type           string `json:"type"`
-	Name           string `json:"name"`
-	ReportingHosts uint32 `json:"reportingHosts"`
+	Type                        string `json:"type"`
+	Name                        string `json:"name"`
+	ReportingHosts              uint32 `json:"reportingHosts"`
 
-	CurrentActiveCount        uint32 `json:"currentActiveCount"`
-	CurrentCompletedTaskCount uint32 `json:"currentCompletedTaskCount"`
-	CurrentCorePoolSize       uint32 `json:"currentCorePoolSize"`
-	CurrentLargestPoolSize    uint32 `json:"currentLargestPoolSize"`
-	CurrentMaximumPoolSize    uint32 `json:"currentMaximumPoolSize"`
-	CurrentPoolSize           uint32 `json:"currentPoolSize"`
-	CurrentQueueSize          uint32 `json:"currentQueueSize"`
-	CurrentTaskCount          uint32 `json:"currentTaskCount"`
+	CurrentActiveCount          uint32 `json:"currentActiveCount"`
+	CurrentCompletedTaskCount   uint32 `json:"currentCompletedTaskCount"`
+	CurrentCorePoolSize         uint32 `json:"currentCorePoolSize"`
+	CurrentLargestPoolSize      uint32 `json:"currentLargestPoolSize"`
+	CurrentMaximumPoolSize      uint32 `json:"currentMaximumPoolSize"`
+	CurrentPoolSize             uint32 `json:"currentPoolSize"`
+	CurrentQueueSize            uint32 `json:"currentQueueSize"`
+	CurrentTaskCount            uint32 `json:"currentTaskCount"`
 
 	RollingMaxActiveThreads     uint32 `json:"rollingMaxActiveThreads"`
 	RollingCountThreadsExecuted uint32 `json:"rollingCountThreadsExecuted"`

--- a/hystrix/eventstream_test.go
+++ b/hystrix/eventstream_test.go
@@ -45,7 +45,7 @@ func sleepingCommand(t *testing.T, name string, duration time.Duration) {
 
 	select {
 	case _ = <-done:
-		// do nothing
+	// do nothing
 	case err := <-errChan:
 		t.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func failingCommand(t *testing.T, name string, duration time.Duration) {
 	case _ = <-done:
 		t.Fatal("should not have succeeded")
 	case _ = <-errChan:
-		// do nothing
+	// do nothing
 	}
 }
 
@@ -153,8 +153,8 @@ func TestEventStream(t *testing.T) {
 		defer server.stopTestServer()
 
 		Convey("after 2 successful commands", func() {
-			sleepingCommand(t, "eventstream", 1*time.Millisecond)
-			sleepingCommand(t, "eventstream", 1*time.Millisecond)
+			sleepingCommand(t, "eventstream", 1 * time.Millisecond)
+			sleepingCommand(t, "eventstream", 1 * time.Millisecond)
 
 			Convey("request count should be 2", func() {
 				event := grabFirstCommandFromStream(t, server.URL)
@@ -165,9 +165,9 @@ func TestEventStream(t *testing.T) {
 		})
 
 		Convey("after 1 successful command and 2 unsuccessful commands", func() {
-			sleepingCommand(t, "errorpercent", 1*time.Millisecond)
-			failingCommand(t, "errorpercent", 1*time.Millisecond)
-			failingCommand(t, "errorpercent", 1*time.Millisecond)
+			sleepingCommand(t, "errorpercent", 1 * time.Millisecond)
+			failingCommand(t, "errorpercent", 1 * time.Millisecond)
+			failingCommand(t, "errorpercent", 1 * time.Millisecond)
 
 			Convey("the error precentage should be 67", func() {
 				metric := grabFirstCommandFromStream(t, server.URL)
@@ -183,7 +183,7 @@ func TestClientCancelEventStream(t *testing.T) {
 		server := startTestServer()
 		defer server.stopTestServer()
 
-		sleepingCommand(t, "eventstream", 1*time.Millisecond)
+		sleepingCommand(t, "eventstream", 1 * time.Millisecond)
 
 		Convey("after a client connects", func() {
 			req, err := http.NewRequest("GET", server.URL, nil)
@@ -209,11 +209,11 @@ func TestClientCancelEventStream(t *testing.T) {
 				for {
 					select {
 					case <-wait:
-						//wait for master goroutine to break us out
+					//wait for master goroutine to break us out
 						tr.CancelRequest(req)
 						return
 					default:
-						//read something
+					//read something
 						_, err = res.Body.Read(buf)
 						if err != nil {
 							t.Fatal(err)
@@ -255,7 +255,7 @@ func TestThreadPoolStream(t *testing.T) {
 		defer server.stopTestServer()
 
 		Convey("after a successful command", func() {
-			sleepingCommand(t, "threadpool", 1*time.Millisecond)
+			sleepingCommand(t, "threadpool", 1 * time.Millisecond)
 			metric := grabFirstThreadPoolFromStream(t, server.URL)
 
 			Convey("the rolling count of executions should increment", func() {

--- a/hystrix/hystrix.go
+++ b/hystrix/hystrix.go
@@ -74,7 +74,9 @@ func Go(name string, run runFunc, fallback fallbackFunc) chan error {
 	cmd.circuit = circuit
 
 	go func() {
-		defer func() { cmd.finished <- true }()
+		defer func() {
+			cmd.finished <- true
+		}()
 
 		// Circuits get opened when recent executions have shown to have a high error rate.
 		// Rejecting new executions allows backends to recover, and the circuit will allow

--- a/hystrix/metric_collector/default_metric_collector.go
+++ b/hystrix/metric_collector/default_metric_collector.go
@@ -25,6 +25,9 @@ type DefaultMetricCollector struct {
 	shortCircuits *rolling.Number
 	timeouts      *rolling.Number
 
+	activeCount    *rolling.Number
+	maxActiveCount *rolling.Number
+
 	fallbackSuccesses *rolling.Number
 	fallbackFailures  *rolling.Number
 	totalDuration     *rolling.Timing
@@ -99,6 +102,20 @@ func (d *DefaultMetricCollector) FallbackFailures() *rolling.Number {
 	d.mutex.RLock()
 	defer d.mutex.RUnlock()
 	return d.fallbackFailures
+}
+
+// ActiveCount returns the rolling number of active thread count
+func (d *DefaultMetricCollector) ActiveCount() *rolling.Number {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	return d.activeCount
+}
+
+// MaxActiveCount returns the rolling number of maximum active thread count
+func (d *DefaultMetricCollector) MaxActiveCount() *rolling.Number {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	return d.maxActiveCount
 }
 
 // TotalDuration returns the rolling total duration
@@ -179,6 +196,20 @@ func (d *DefaultMetricCollector) IncrementFallbackFailures() {
 	d.fallbackFailures.Increment(1)
 }
 
+// UpdateActiveCount updates the number of active threads in the pool in the latest time bucket
+func (d *DefaultMetricCollector) UpdateActiveCount(currentActiveCount int) {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	d.activeCount.Increment(float64(currentActiveCount))
+}
+
+// UpdateMaxActiveCount updates the number of maximum active threads count in the pool in the latest time bucket
+func (d *DefaultMetricCollector) UpdateMaxActiveCount(maxActiveCount int) {
+	d.mutex.RLock()
+	defer d.mutex.RUnlock()
+	d.maxActiveCount.Increment(float64(maxActiveCount))
+}
+
 // UpdateTotalDuration updates the total amount of time this circuit has been running.
 func (d *DefaultMetricCollector) UpdateTotalDuration(timeSinceStart time.Duration) {
 	d.mutex.RLock()
@@ -209,4 +240,6 @@ func (d *DefaultMetricCollector) Reset() {
 	d.fallbackFailures = rolling.NewNumber()
 	d.totalDuration = rolling.NewTiming()
 	d.runDuration = rolling.NewTiming()
+	d.activeCount = rolling.NewNumber()
+	d.maxActiveCount = rolling.NewNumber()
 }

--- a/hystrix/metric_collector/default_metric_collector.go
+++ b/hystrix/metric_collector/default_metric_collector.go
@@ -14,19 +14,19 @@ import (
 //
 // Metric Collectors do not need Mutexes as they are updated by circuits within a locked context.
 type DefaultMetricCollector struct {
-	mutex *sync.RWMutex
+	mutex             *sync.RWMutex
 
-	numRequests *rolling.Number
-	errors      *rolling.Number
+	numRequests       *rolling.Number
+	errors            *rolling.Number
 
-	successes     *rolling.Number
-	failures      *rolling.Number
-	rejects       *rolling.Number
-	shortCircuits *rolling.Number
-	timeouts      *rolling.Number
+	successes         *rolling.Number
+	failures          *rolling.Number
+	rejects           *rolling.Number
+	shortCircuits     *rolling.Number
+	timeouts          *rolling.Number
 
-	activeCount    *rolling.Number
-	maxActiveCount *rolling.Number
+	activeCount       *rolling.Number
+	maxActiveCount    *rolling.Number
 
 	fallbackSuccesses *rolling.Number
 	fallbackFailures  *rolling.Number

--- a/hystrix/metric_collector/metric_collector.go
+++ b/hystrix/metric_collector/metric_collector.go
@@ -63,6 +63,10 @@ type MetricCollector interface {
 	IncrementFallbackSuccesses()
 	// IncrementFallbackFailures increments the number of failures that occurred during the execution of the fallback function.
 	IncrementFallbackFailures()
+	// UpdateActiveCount updates the number of active threads in the pool in the latest time bucket
+	UpdateActiveCount(currentActiveCount int)
+	// UpdateMaxActiveCount updates the number of maximum active threads count in the pool in the latest time bucket
+	UpdateMaxActiveCount(maxActiveCount int)
 	// UpdateTotalDuration updates the internal counter of how long we've run for.
 	UpdateTotalDuration(timeSinceStart time.Duration)
 	// UpdateRunDuration updates the internal counter of how long the last run took.

--- a/hystrix/metrics.go
+++ b/hystrix/metrics.go
@@ -9,17 +9,17 @@ import (
 )
 
 type commandExecution struct {
-	Types       []string      `json:"types"`
-	Start       time.Time     `json:"start_time"`
-	RunDuration time.Duration `json:"run_duration"`
+	Types                     []string      `json:"types"`
+	Start                     time.Time     `json:"start_time"`
+	RunDuration               time.Duration `json:"run_duration"`
 	CurrentActiveCount        int           `json:"active_count"`
 	CurrentMaximumActiveCount int           `json:"max_active_count"`
 }
 
 type metricExchange struct {
-	Name    string
-	Updates chan *commandExecution
-	Mutex   *sync.RWMutex
+	Name             string
+	Updates          chan *commandExecution
+	Mutex            *sync.RWMutex
 
 	metricCollectors []metricCollector.MetricCollector
 }

--- a/hystrix/metrics.go
+++ b/hystrix/metrics.go
@@ -12,6 +12,8 @@ type commandExecution struct {
 	Types       []string      `json:"types"`
 	Start       time.Time     `json:"start_time"`
 	RunDuration time.Duration `json:"run_duration"`
+	CurrentActiveCount        int           `json:"active_count"`
+	CurrentMaximumActiveCount int           `json:"max_active_count"`
 }
 
 type metricExchange struct {
@@ -108,6 +110,9 @@ func (m *metricExchange) IncrementMetrics(wg *sync.WaitGroup, collector metricCo
 
 	collector.UpdateTotalDuration(totalDuration)
 	collector.UpdateRunDuration(update.RunDuration)
+
+	collector.UpdateActiveCount(update.CurrentActiveCount)
+	collector.UpdateMaxActiveCount(update.CurrentMaximumActiveCount)
 
 	wg.Done()
 }

--- a/hystrix/pool_metrics.go
+++ b/hystrix/pool_metrics.go
@@ -7,8 +7,8 @@ import (
 )
 
 type poolMetrics struct {
-	Mutex   *sync.RWMutex
-	Updates chan poolMetricsUpdate
+	Mutex             *sync.RWMutex
+	Updates           chan poolMetricsUpdate
 
 	Name              string
 	MaxActiveRequests *rolling.Number

--- a/hystrix/rolling/rolling.go
+++ b/hystrix/rolling/rolling.go
@@ -80,7 +80,7 @@ func (r *Number) Sum(now time.Time) float64 {
 
 	for timestamp, bucket := range r.Buckets {
 		// TODO: configurable rolling window
-		if timestamp >= now.Unix()-10 {
+		if timestamp >= now.Unix() - 10 {
 			sum += bucket.Value
 		}
 	}
@@ -97,7 +97,7 @@ func (r *Number) Max(now time.Time) float64 {
 
 	for timestamp, bucket := range r.Buckets {
 		// TODO: configurable rolling window
-		if timestamp >= now.Unix()-10 {
+		if timestamp >= now.Unix() - 10 {
 			if bucket.Value > max {
 				max = bucket.Value
 			}

--- a/hystrix/rolling/rolling_timing.go
+++ b/hystrix/rolling/rolling_timing.go
@@ -11,8 +11,8 @@ import (
 // The Durations are kept in an array to allow for a variety of
 // statistics to be calculated from the source data.
 type Timing struct {
-	Buckets map[int64]*timingBucket
-	Mutex   *sync.RWMutex
+	Buckets               map[int64]*timingBucket
+	Mutex                 *sync.RWMutex
 
 	CachedSortedDurations []time.Duration
 	LastCachedTime        int64
@@ -33,9 +33,15 @@ func NewTiming() *Timing {
 
 type byDuration []time.Duration
 
-func (c byDuration) Len() int           { return len(c) }
-func (c byDuration) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
-func (c byDuration) Less(i, j int) bool { return c[i] < c[j] }
+func (c byDuration) Len() int {
+	return len(c)
+}
+func (c byDuration) Swap(i, j int) {
+	c[i], c[j] = c[j], c[i]
+}
+func (c byDuration) Less(i, j int) bool {
+	return c[i] < c[j]
+}
 
 // SortedDurations returns an array of time.Duration sorted from shortest
 // to longest that have occurred in the last 60 seconds.
@@ -44,7 +50,7 @@ func (r *Timing) SortedDurations() []time.Duration {
 	t := r.LastCachedTime
 	r.Mutex.RUnlock()
 
-	if t+time.Duration(1*time.Second).Nanoseconds() > time.Now().UnixNano() {
+	if t + time.Duration(1 * time.Second).Nanoseconds() > time.Now().UnixNano() {
 		// don't recalculate if current cache is still fresh
 		return r.CachedSortedDurations
 	}
@@ -57,7 +63,7 @@ func (r *Timing) SortedDurations() []time.Duration {
 
 	for timestamp, b := range r.Buckets {
 		// TODO: configurable rolling window
-		if timestamp >= now.Unix()-60 {
+		if timestamp >= now.Unix() - 60 {
 			for _, d := range b.Durations {
 				durations = append(durations, d)
 			}
@@ -94,7 +100,7 @@ func (r *Timing) removeOldBuckets() {
 
 	for timestamp := range r.Buckets {
 		// TODO: configurable rolling window
-		if timestamp <= now.Unix()-60 {
+		if timestamp <= now.Unix() - 60 {
 			delete(r.Buckets, timestamp)
 		}
 	}
@@ -144,5 +150,5 @@ func (r *Timing) Mean() uint32 {
 		return 0
 	}
 
-	return uint32(sum.Nanoseconds()/length) / 1000000
+	return uint32(sum.Nanoseconds() / length) / 1000000
 }

--- a/hystrix/settings_test.go
+++ b/hystrix/settings_test.go
@@ -22,7 +22,7 @@ func TestConfigureTimeout(t *testing.T) {
 		ConfigureCommand("", CommandConfig{Timeout: 10000})
 
 		Convey("reading the timeout should be the same", func() {
-			So(getSettings("").Timeout, ShouldEqual, time.Duration(10*time.Second))
+			So(getSettings("").Timeout, ShouldEqual, time.Duration(10 * time.Second))
 		})
 	})
 }
@@ -42,7 +42,7 @@ func TestSleepWindowDefault(t *testing.T) {
 		ConfigureCommand("", CommandConfig{})
 
 		Convey("the sleep window should be 5 seconds", func() {
-			So(getSettings("").SleepWindow, ShouldEqual, time.Duration(5*time.Second))
+			So(getSettings("").SleepWindow, ShouldEqual, time.Duration(5 * time.Second))
 		})
 	})
 }
@@ -53,7 +53,7 @@ func TestGetCircuitSettings(t *testing.T) {
 
 		Convey("should read the same setting just added", func() {
 			So(GetCircuitSettings()["test"], ShouldEqual, getSettings("test"))
-			So(GetCircuitSettings()["test"].Timeout, ShouldEqual, time.Duration(30*time.Second))
+			So(GetCircuitSettings()["test"].Timeout, ShouldEqual, time.Duration(30 * time.Second))
 		})
 	})
 }

--- a/loadtest/service/main.go
+++ b/loadtest/service/main.go
@@ -19,8 +19,8 @@ import (
 
 const (
 	deltaWindow = 10
-	minDelay    = 35
-	maxDelay    = 55
+	minDelay = 35
+	maxDelay = 55
 )
 
 var (
@@ -78,7 +78,7 @@ func handle(w http.ResponseWriter, r *http.Request) {
 	done := make(chan struct{}, 1)
 	errChan := hystrix.Go("test", func() error {
 		delta := rand.Intn(deltaWindow)
-		time.Sleep(time.Duration(delay+delta) * time.Millisecond)
+		time.Sleep(time.Duration(delay + delta) * time.Millisecond)
 		done <- struct{}{}
 		return nil
 	}, func(err error) error {

--- a/plugins/datadog_collector.go
+++ b/plugins/datadog_collector.go
@@ -15,20 +15,20 @@ import (
 // own implemenation of DatadogClient
 const (
 	// DM = Datadog Metric
-	DM_CircuitOpen       = "hystrix.circuitOpen"
-	DM_Attempts          = "hystrix.attempts"
-	DM_Errors            = "hystrix.errors"
-	DM_Successes         = "hystrix.successes"
-	DM_Failures          = "hystrix.failures"
-	DM_Rejects           = "hystrix.rejects"
-	DM_ShortCircuits     = "hystrix.shortCircuits"
-	DM_Timeouts          = "hystrix.timeouts"
+	DM_CircuitOpen = "hystrix.circuitOpen"
+	DM_Attempts = "hystrix.attempts"
+	DM_Errors = "hystrix.errors"
+	DM_Successes = "hystrix.successes"
+	DM_Failures = "hystrix.failures"
+	DM_Rejects = "hystrix.rejects"
+	DM_ShortCircuits = "hystrix.shortCircuits"
+	DM_Timeouts = "hystrix.timeouts"
 	DM_FallbackSuccesses = "hystrix.fallbackSuccesses"
-	DM_FallbackFailures  = "hystrix.fallbackFailures"
-	DM_TotalDuration     = "hystrix.totalDuration"
-	DM_RunDuration       = "hystrix.runDuration"
-	DM_ActiveCount       = "hystrix.activeCount"
-	DM_MaxActiveCount    = "hystrix.maxActiveCount"
+	DM_FallbackFailures = "hystrix.fallbackFailures"
+	DM_TotalDuration = "hystrix.totalDuration"
+	DM_RunDuration = "hystrix.runDuration"
+	DM_ActiveCount = "hystrix.activeCount"
+	DM_MaxActiveCount = "hystrix.maxActiveCount"
 )
 
 type (

--- a/plugins/datadog_collector.go
+++ b/plugins/datadog_collector.go
@@ -27,6 +27,8 @@ const (
 	DM_FallbackFailures  = "hystrix.fallbackFailures"
 	DM_TotalDuration     = "hystrix.totalDuration"
 	DM_RunDuration       = "hystrix.runDuration"
+	DM_ActiveCount       = "hystrix.activeCount"
+	DM_MaxActiveCount    = "hystrix.maxActiveCount"
 )
 
 type (
@@ -166,6 +168,16 @@ func (dc *DatadogCollector) IncrementFallbackSuccesses() {
 // during the execution of the fallback function.
 func (dc *DatadogCollector) IncrementFallbackFailures() {
 	dc.client.Count(DM_FallbackFailures, 1, dc.tags, 1.0)
+}
+
+// UpdateActiveCount updates the number of active threads in the execution pool
+func (dc *DatadogCollector) UpdateActiveCount(activeCount int) {
+	dc.client.Gauge(DM_ActiveCount, float64(activeCount), dc.tags, 1.0)
+}
+
+// UpdateMaxActiveCount updates the maximum number of active threads in the execution pool
+func (dc *DatadogCollector) UpdateMaxActiveCount(maxActiveCount int) {
+	dc.client.Gauge(DM_MaxActiveCount, float64(maxActiveCount), dc.tags, 1.0)
 }
 
 // UpdateTotalDuration updates the internal counter of how long we've run for.

--- a/plugins/graphite_aggregator.go
+++ b/plugins/graphite_aggregator.go
@@ -11,9 +11,15 @@ import (
 	"github.com/rcrowley/go-metrics"
 )
 
-var makeTimerFunc = func() interface{} { return metrics.NewTimer() }
-var makeCounterFunc = func() interface{} { return metrics.NewCounter() }
-var makeGaugeFunc = func() interface{} { return metrics.NewGauge() }
+var makeTimerFunc = func() interface{} {
+	return metrics.NewTimer()
+}
+var makeCounterFunc = func() interface{} {
+	return metrics.NewCounter()
+}
+var makeGaugeFunc = func() interface{} {
+	return metrics.NewGauge()
+}
 
 // GraphiteCollector fulfills the metricCollector interface allowing users to ship circuit
 // stats to a graphite backend. To use users must call InitializeGraphiteCollector before
@@ -42,7 +48,7 @@ type GraphiteCollectorConfig struct {
 	// GraphiteAddr is the tcp address of the graphite server
 	GraphiteAddr *net.TCPAddr
 	// Prefix is the prefix that will be prepended to all metrics sent from this collector.
-	Prefix string
+	Prefix       string
 	// TickInterval spcifies the period that this collector will send metrics to the server.
 	TickInterval time.Duration
 }

--- a/plugins/statsd_collector.go
+++ b/plugins/statsd_collector.go
@@ -28,6 +28,8 @@ type StatsdCollector struct {
 	fallbackFailuresPrefix  string
 	totalDurationPrefix     string
 	runDurationPrefix       string
+	activeCountPrefix       string
+	maxActiveCountPrefix    string
 	sampleRate              float32
 }
 
@@ -188,6 +190,18 @@ func (g *StatsdCollector) IncrementFallbackSuccesses() {
 // This registers as a counter in the Statsd collector.
 func (g *StatsdCollector) IncrementFallbackFailures() {
 	g.incrementCounterMetric(g.fallbackFailuresPrefix)
+}
+
+// UpdateActiveCount updates the number of active threads in the pool
+// This registers as a gauge in the graphite collector
+func (g *StatsdCollector) UpdateActiveCount(activeCount int) {
+	g.setGauge(g.activeCountPrefix, int64(activeCount))
+}
+
+// UpdateMaxActiveCount updates the maximum number of active threads in the pool
+// This registers as a gauge in the graphite collector
+func (g *StatsdCollector) UpdateMaxActiveCount(maxActiveCount int) {
+	g.setGauge(g.activeCountPrefix, int64(maxActiveCount))
 }
 
 // UpdateTotalDuration updates the internal counter of how long we've run for.

--- a/plugins/statsd_collector.go
+++ b/plugins/statsd_collector.go
@@ -40,8 +40,8 @@ type StatsdCollectorClient struct {
 
 // https://github.com/etsy/statsd/blob/master/docs/metric_types.md#multi-metric-packets
 const (
-	WANStatsdFlushBytes     = 512
-	LANStatsdFlushBytes     = 1432
+	WANStatsdFlushBytes = 512
+	LANStatsdFlushBytes = 1432
 	GigabitStatsdFlushBytes = 8932
 )
 
@@ -50,7 +50,7 @@ type StatsdCollectorConfig struct {
 	// StatsdAddr is the tcp address of the Statsd server
 	StatsdAddr string
 	// Prefix is the prefix that will be prepended to all metrics sent from this collector.
-	Prefix string
+	Prefix     string
 	// StatsdSampleRate sets statsd sampling. If 0, defaults to 1.0. (no sampling)
 	SampleRate float32
 	// FlushBytes sets message size for statsd packets. If 0, defaults to LANFlushSize.
@@ -72,7 +72,7 @@ func InitializeStatsdCollector(config *StatsdCollectorConfig) (*StatsdCollectorC
 		sampleRate = 1
 	}
 
-	c, err := statsd.NewBufferedClient(config.StatsdAddr, config.Prefix, 1*time.Second, flushBytes)
+	c, err := statsd.NewBufferedClient(config.StatsdAddr, config.Prefix, 1 * time.Second, flushBytes)
 	if err != nil {
 		log.Printf("Could not initiale buffered client: %s. Falling back to a Noop Statsd client", err)
 		c, _ = statsd.NewNoopClient()


### PR DESCRIPTION
Adding the active count (number of active threads in the execution pool) and max active count as metrics in the metrics collector in order to allow data retrieval for these metrics in supported plugins.

Gofmt the projects.