### PR TITLE
Add circuitEnable command property from https://github.com/Netflix/Hy…

### DIFF
--- a/hystrix/circuit.go
+++ b/hystrix/circuit.go
@@ -91,6 +91,10 @@ func (circuit *CircuitBreaker) toggleForceOpen(toggle bool) error {
 // IsOpen is called before any Command execution to check whether or
 // not it should be attempted. An "open" circuit means it is disabled.
 func (circuit *CircuitBreaker) IsOpen() bool {
+	if (!getSettings(circuit.Name).Enabled) {
+		return false
+	}
+
 	circuit.mutex.RLock()
 	o := circuit.forceOpen || circuit.open
 	circuit.mutex.RUnlock()
@@ -137,6 +141,10 @@ func (circuit *CircuitBreaker) allowSingleTest() bool {
 }
 
 func (circuit *CircuitBreaker) setOpen() {
+	if (!getSettings(circuit.Name).Enabled) {
+		return
+	}
+
 	circuit.mutex.Lock()
 	defer circuit.mutex.Unlock()
 
@@ -151,6 +159,10 @@ func (circuit *CircuitBreaker) setOpen() {
 }
 
 func (circuit *CircuitBreaker) setClose() {
+	if (!getSettings(circuit.Name).Enabled) {
+		return
+	}
+	
 	circuit.mutex.Lock()
 	defer circuit.mutex.Unlock()
 

--- a/hystrix/settings.go
+++ b/hystrix/settings.go
@@ -16,6 +16,8 @@ var (
 	DefaultSleepWindow = 5000
 	// DefaultErrorPercentThreshold causes circuits to open once the rolling measure of errors exceeds this percent of requests
 	DefaultErrorPercentThreshold = 50
+	//DefaultEnabled makes the circuit to be able to be closed
+	DefaultEnabled = true
 )
 
 type Settings struct {
@@ -24,6 +26,7 @@ type Settings struct {
 	RequestVolumeThreshold uint64
 	SleepWindow            time.Duration
 	ErrorPercentThreshold  int
+	Enabled                bool
 }
 
 // CommandConfig is used to tune circuit settings at runtime
@@ -33,6 +36,7 @@ type CommandConfig struct {
 	RequestVolumeThreshold int `json:"request_volume_threshold"`
 	SleepWindow            int `json:"sleep_window"`
 	ErrorPercentThreshold  int `json:"error_percent_threshold"`
+	Enabled                bool `json:"circuit_enabled"`
 }
 
 var circuitSettings map[string]*Settings
@@ -80,12 +84,18 @@ func ConfigureCommand(name string, config CommandConfig) {
 		errorPercent = config.ErrorPercentThreshold
 	}
 
+	enabled := DefaultEnabled
+	if config.Enabled != DefaultEnabled {
+		enabled = config.Enabled
+	}
+
 	circuitSettings[name] = &Settings{
 		Timeout:                time.Duration(timeout) * time.Millisecond,
 		MaxConcurrentRequests:  max,
 		RequestVolumeThreshold: uint64(volume),
 		SleepWindow:            time.Duration(sleep) * time.Millisecond,
 		ErrorPercentThreshold:  errorPercent,
+		Enabled:                enabled,
 	}
 }
 


### PR DESCRIPTION
…strix/wiki/Configuration#circuitBreaker.enabled

We need to wrap a function with a hystrix command to enforce a timeout on it.
Since the function only acts in the local machine and it is always a best effort, we don't what the circuit to be closed when there are errors.

See original hystrix property:
https://github.com/Netflix/Hystrix/wiki/Configuration#circuitBreaker.enabled