### PR TITLE
ReportEvent() race condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,9 @@ script:
   - cd hystrix
   - go test -race
 go:
-  - 1.3.3
-  - 1.4.3
-  - 1.5.4
-  - 1.6.0
-  - 1.6.1
-  - 1.6.2
+  - 1.6
+  - 1.7
+  - 1.8
   - tip
 env:
   global:

--- a/hystrix/circuit.go
+++ b/hystrix/circuit.go
@@ -170,7 +170,10 @@ func (circuit *CircuitBreaker) ReportEvent(eventTypes []string, start time.Time,
 		return fmt.Errorf("no event types sent for metrics")
 	}
 
-	if eventTypes[0] == "success" && circuit.open {
+	circuit.mutex.RLock()
+	o := circuit.open
+	circuit.mutex.RUnlock()
+	if eventTypes[0] == "success" && o {
 		circuit.setClose()
 	}
 


### PR DESCRIPTION
CircuitBreaker.ReportEvent() checks Circuit.open without acquiring a lock. It's possible to run into data race when other goroutines running for example CircuitBreaker.setOpen().

This problem can be observed by running the test I add with package quick:


(Checkout [#346dd5d](https://github.com/cfchou/hystrix-go/commit/346dd5d85f75658606ff20e5a870fc6a655b8342) and increase `-quickchecks` if not seeing race condition.)

```
go test -race github.com/cfchou/hystrix-go/hystrix -test.v -test.run ^TestReportEventMultiThreaded$ -quickchecks 50
...
==================
WARNING: DATA RACE
Write at 0x00c420106dd0 by goroutine 81:
  github.com/cfchou/hystrix-go/hystrix.(*CircuitBreaker).setOpen()
      /Users/cfchou/Project/gopath/src/github.com/cfchou/hystrix-go/hystrix/circuit.go:150 +0x1c9
  github.com/cfchou/hystrix-go/hystrix.(*CircuitBreaker).IsOpen()
      /Users/cfchou/Project/gopath/src/github.com/cfchou/hystrix-go/hystrix/circuit.go:108 +0x21e
  github.com/cfchou/hystrix-go/hystrix.TestReportEvent.func1.1()
      /Users/cfchou/Project/gopath/src/github.com/cfchou/hystrix-go/hystrix/circuit_test.go:137 +0x2bd

Previous read at 0x00c420106dd0 by goroutine 64:
  github.com/cfchou/hystrix-go/hystrix.(*CircuitBreaker).ReportEvent()
      /Users/cfchou/Project/gopath/src/github.com/cfchou/hystrix-go/hystrix/circuit.go:173 +0x393
  github.com/cfchou/hystrix-go/hystrix.TestReportEvent.func1.1()
      /Users/cfchou/Project/gopath/src/github.com/cfchou/hystrix-go/hystrix/circuit_test.go:131 +0x170
...
```