### PR TITLE
Request Buffer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+*.iml
+.idea/
 .vagrant

--- a/README.md
+++ b/README.md
@@ -87,9 +87,10 @@ During application boot, you can call ```hystrix.ConfigureCommand()``` to tweak 
 
 ```go
 hystrix.ConfigureCommand("my_command", hystrix.CommandConfig{
-	Timeout:               1000,
-	MaxConcurrentRequests: 100,
-	ErrorPercentThreshold: 25,
+	Timeout:                     1000,
+	MaxConcurrentRequests:       100,
+	ErrorPercentThreshold:       25,
+	QueueSizeRejectionThreshold: 100,
 })
 ```
 

--- a/hystrix/circuit.go
+++ b/hystrix/circuit.go
@@ -17,7 +17,7 @@ type CircuitBreaker struct {
 	mutex                  *sync.RWMutex
 	openedOrLastTestedTime int64
 
-	executorPool *executorPool
+	executorPool *bufferedExecutorPool
 	metrics      *metricExchange
 }
 
@@ -42,7 +42,7 @@ func GetCircuit(name string) (*CircuitBreaker, bool, error) {
 		// because we released the rlock before we obtained the exclusive lock,
 		// we need to double check that some other thread didn't beat us to
 		// creation.
-		if cb, ok := circuitBreakers[name]; ok {
+		if cb, present := circuitBreakers[name]; present {
 			return cb, false, nil
 		}
 		circuitBreakers[name] = newCircuitBreaker(name)
@@ -70,7 +70,7 @@ func newCircuitBreaker(name string) *CircuitBreaker {
 	c := &CircuitBreaker{}
 	c.Name = name
 	c.metrics = newMetricExchange(name)
-	c.executorPool = newExecutorPool(name)
+	c.executorPool = newBufferedExecutorPool(name)
 	c.mutex = &sync.RWMutex{}
 
 	return c

--- a/hystrix/circuit_test.go
+++ b/hystrix/circuit_test.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
-	"testing/quick"
 	"math/rand"
+	"testing/quick"
 )
 
 func TestGetCircuit(t *testing.T) {
@@ -103,10 +103,10 @@ func TestReportEventMultiThreaded(t *testing.T) {
 		defer Flush()
 		// Make the circuit easily open and close intermittently.
 		ConfigureCommand("", CommandConfig{
-			MaxConcurrentRequests: 1,
-			ErrorPercentThreshold: 1,
+			MaxConcurrentRequests:  1,
+			ErrorPercentThreshold:  1,
 			RequestVolumeThreshold: 1,
-			SleepWindow: 10,
+			SleepWindow:            10,
 		})
 		cb, _, _ := GetCircuit("")
 		count := 5

--- a/hystrix/eventstream.go
+++ b/hystrix/eventstream.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/vermapratyush/hystrix-go/hystrix/rolling"
+	"github.com/afex/hystrix-go/hystrix/rolling"
 )
 
 const (

--- a/hystrix/eventstream_test.go
+++ b/hystrix/eventstream_test.go
@@ -118,7 +118,9 @@ func streamMetrics(t *testing.T, url string) (chan string, chan bool) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer res.Body.Close()
+		defer func() {
+			_ = res.Body.Close()
+		}()
 
 		buf := []byte{0}
 		data := ""
@@ -150,7 +152,9 @@ func streamMetrics(t *testing.T, url string) (chan string, chan bool) {
 func TestEventStream(t *testing.T) {
 	Convey("given a running event stream", t, func() {
 		server := startTestServer()
-		defer server.stopTestServer()
+		defer func() {
+			_ = server.stopTestServer()
+		}()
 
 		Convey("after 2 successful commands", func() {
 			sleepingCommand(t, "eventstream", 1*time.Millisecond)
@@ -181,7 +185,9 @@ func TestEventStream(t *testing.T) {
 func TestClientCancelEventStream(t *testing.T) {
 	Convey("given a running event stream", t, func() {
 		server := startTestServer()
-		defer server.stopTestServer()
+		defer func() {
+			_ = server.stopTestServer()
+		}()
 
 		sleepingCommand(t, "eventstream", 1*time.Millisecond)
 
@@ -204,7 +210,9 @@ func TestClientCancelEventStream(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				defer res.Body.Close()
+				defer func() {
+					_ = res.Body.Close()
+				}()
 
 				for {
 					select {
@@ -252,7 +260,9 @@ func TestClientCancelEventStream(t *testing.T) {
 func TestThreadPoolStream(t *testing.T) {
 	Convey("given a running event stream", t, func() {
 		server := startTestServer()
-		defer server.stopTestServer()
+		defer func() {
+			_ = server.stopTestServer()
+		}()
 
 		Convey("after a successful command", func() {
 			sleepingCommand(t, "threadpool", 1*time.Millisecond)

--- a/hystrix/hystrix.go
+++ b/hystrix/hystrix.go
@@ -23,17 +23,22 @@ func (e CircuitError) Error() string {
 // command models the state used for a single execution on a circuit. "hystrix command" is commonly
 // used to describe the pairing of your run/fallback functions with a circuit.
 type command struct {
-	sync.Mutex
+	sync.RWMutex
 
-	ticket       *struct{}
-	start        time.Time
-	errChan      chan error
-	finished     chan bool
-	circuit      *CircuitBreaker
-	run          runFunc
-	fallback     fallbackFunc
-	runDuration  time.Duration
-	events       []string
+	ticket         *struct{}
+	overflowTicket *struct{}
+	start          time.Time
+	errChan        chan error
+	finished       chan bool
+	timeoutChan    chan struct{}
+	fallbackOnce   *sync.Once
+	circuit        *CircuitBreaker
+	run            runFunc
+	fallback       fallbackFunc
+	runDuration    time.Duration
+	events         []string
+	timedOut       bool
+	ticketChecked  chan struct{}
 }
 
 var (
@@ -52,11 +57,14 @@ var (
 // Define a fallback function if you want to define some code to execute during outages.
 func Go(name string, run runFunc, fallback fallbackFunc) chan error {
 	cmd := &command{
-		run:          run,
-		fallback:     fallback,
-		start:        time.Now(),
-		errChan:      make(chan error, 1),
-		finished:     make(chan bool, 1),
+		run:           run,
+		fallback:      fallback,
+		start:         time.Now(),
+		errChan:       make(chan error, 1),
+		finished:      make(chan bool, 1),
+		fallbackOnce:  &sync.Once{},
+		timeoutChan:   make(chan struct{}, 1),
+		ticketChecked: make(chan struct{}, 1),
 	}
 
 	// dont have methods with explicit params and returns
@@ -69,47 +77,18 @@ func Go(name string, run runFunc, fallback fallbackFunc) chan error {
 		return cmd.errChan
 	}
 	cmd.circuit = circuit
-	ticketCond := sync.NewCond(cmd)
-	ticketChecked := false
-	// When the caller extracts error from returned errChan, it's assumed that
-	// the ticket's been returned to executorPool. Therefore, returnTicket() can
-	// not run after cmd.errorWithFallback().
-	returnTicket := func() {
-		cmd.Lock()
-		// Avoid releasing before a ticket is acquired.
-		for !ticketChecked {
-			ticketCond.Wait()
-		}
-		cmd.circuit.executorPool.Return(cmd.ticket)
-		cmd.Unlock()
-	}
-	// Shared by the following two goroutines. It ensures only the faster
-	// goroutine runs errWithFallback() and reportAllEvent().
-	returnOnce := &sync.Once{}
-	reportAllEvent := func() {
-		err := cmd.circuit.ReportEvent(cmd.events, cmd.start, cmd.runDuration)
-		if err != nil {
-			log.Print(err)
-		}
-	}
 
 	go func() {
-		defer func() { cmd.finished <- true }()
+		defer func() {
+			cmd.finished <- true
+		}()
 
 		// Circuits get opened when recent executions have shown to have a high error rate.
 		// Rejecting new executions allows backends to recover, and the circuit will allow
 		// new traffic when it feels a healthly state has returned.
 		if !cmd.circuit.AllowRequest() {
-			cmd.Lock()
-			// It's safe for another goroutine to go ahead releasing a nil ticket.
-			ticketChecked = true
-			ticketCond.Signal()
-			cmd.Unlock()
-			returnOnce.Do(func() {
-				returnTicket()
-				cmd.errorWithFallback(ErrCircuitOpen)
-				reportAllEvent()
-			})
+			cmd.errorWithFallback(ErrCircuitOpen)
+			close(cmd.ticketChecked)
 			return
 		}
 
@@ -118,51 +97,89 @@ func Go(name string, run runFunc, fallback fallbackFunc) chan error {
 		// When requests slow down but the incoming rate of requests stays the same, you have to
 		// run more at a time to keep up. By controlling concurrency during these situations, you can
 		// shed load which accumulates due to the increasing ratio of active commands to incoming requests.
-		cmd.Lock()
+
 		select {
-		case cmd.ticket = <-circuit.executorPool.Tickets:
-			ticketChecked = true
-			ticketCond.Signal()
-			cmd.Unlock()
+		case t := <-circuit.executorPool.Tickets:
+			cmd.setTicket(t)
+
 		default:
-			ticketChecked = true
-			ticketCond.Signal()
-			cmd.Unlock()
-			returnOnce.Do(func() {
-				returnTicket()
+			select {
+			case t := <-circuit.executorPool.WaitingTicket:
+				cmd.reportEvent("queued")
+				cmd.setOverflowTicket(t)
+			default: // Unable to get execution or waiting ticket, error with MaxConcurrency
 				cmd.errorWithFallback(ErrMaxConcurrency)
-				reportAllEvent()
-			})
-			return
+				close(cmd.ticketChecked)
+				return
+			}
+
+			// Unable to execute the cmd but was able to get the waiting slot
+			select {
+			case executionTicket := <-circuit.executorPool.Tickets:
+				// return the ticket right away as it is not required
+				cmd.circuit.executorPool.ReturnWaitingTicket(cmd.overflowTicket)
+				cmd.setTicket(executionTicket)
+				isOpen := circuit.IsOpen()
+				if isOpen {
+					cmd.errorWithFallback(ErrCircuitOpen)
+					close(cmd.ticketChecked)
+					return
+				}
+			case <-cmd.timeoutChan:
+				// return the ticket right away as it is not required
+				cmd.circuit.executorPool.ReturnWaitingTicket(cmd.overflowTicket)
+				close(cmd.ticketChecked)
+				return
+			}
 		}
 
+		close(cmd.ticketChecked)
 		runStart := time.Now()
 		runErr := run()
-		returnOnce.Do(func() {
-			defer reportAllEvent()
-			cmd.runDuration = time.Since(runStart)
-			returnTicket()
+
+		if !cmd.isTimedOut() {
+			cmd.setRunDuration(time.Since(runStart))
+
 			if runErr != nil {
 				cmd.errorWithFallback(runErr)
 				return
 			}
+
 			cmd.reportEvent("success")
-		})
+		}
 	}()
 
 	go func() {
+		defer func() {
+			<-cmd.ticketChecked
+			cmd.Lock()
+			cmd.circuit.executorPool.Return(cmd.ticket)
+			copyEvents := append([]string(nil), cmd.events...)
+			cmd.Unlock()
+
+			err := cmd.circuit.ReportEvent(copyEvents, cmd.start, cmd.getRunDuration())
+			if err != nil {
+				log.Print(err)
+			}
+		}()
+
 		timer := time.NewTimer(getSettings(name).Timeout)
 		defer timer.Stop()
 
 		select {
 		case <-cmd.finished:
-			// returnOnce has been executed in another goroutine
 		case <-timer.C:
-			returnOnce.Do(func() {
-				returnTicket()
+			close(cmd.timeoutChan)
+			// mark as timeout only if the reason is timeout, if the job was in overflowQueue mark it as MaxConcurrency
+			if cmd.getOverflowTicket() == nil {
+				cmd.Lock()
+				cmd.timedOut = true
+				cmd.Unlock()
 				cmd.errorWithFallback(ErrTimeout)
-				reportAllEvent()
-			})
+			} else {
+				// even if the execution was waiting in queue and then timed-out while executing, mark it as ErrMaxConcurrency
+				cmd.errorWithFallback(ErrMaxConcurrency)
+			}
 			return
 		}
 	}()
@@ -217,22 +234,33 @@ func (c *command) reportEvent(eventType string) {
 	c.events = append(c.events, eventType)
 }
 
-// errorWithFallback triggers the fallback while reporting the appropriate metric events.
-func (c *command) errorWithFallback(err error) {
-	eventType := "failure"
-	if err == ErrCircuitOpen {
-		eventType = "short-circuit"
-	} else if err == ErrMaxConcurrency {
-		eventType = "rejected"
-	} else if err == ErrTimeout {
-		eventType = "timeout"
-	}
+func (c *command) isTimedOut() bool {
+	c.RLock()
+	defer c.RUnlock()
 
-	c.reportEvent(eventType)
-	fallbackErr := c.tryFallback(err)
-	if fallbackErr != nil {
-		c.errChan <- fallbackErr
-	}
+	return c.timedOut
+}
+
+// errorWithFallback triggers the fallback while reporting the appropriate metric events.
+// If called multiple times for a single command, only the first will execute to insure
+// accurate metrics and prevent the fallback from executing more than once.
+func (c *command) errorWithFallback(err error) {
+	c.fallbackOnce.Do(func() {
+		eventType := "failure"
+		if err == ErrCircuitOpen {
+			eventType = "short-circuit"
+		} else if err == ErrMaxConcurrency {
+			eventType = "rejected"
+		} else if err == ErrTimeout {
+			eventType = "timeout"
+		}
+
+		c.reportEvent(eventType)
+		fallbackErr := c.tryFallback(err)
+		if fallbackErr != nil {
+			c.errChan <- fallbackErr
+		}
+	})
 }
 
 func (c *command) tryFallback(err error) error {
@@ -250,4 +278,42 @@ func (c *command) tryFallback(err error) error {
 	c.reportEvent("fallback-success")
 
 	return nil
+}
+
+func (c *command) getTicket() *struct{} {
+	c.RLock()
+	defer c.RUnlock()
+
+	return c.ticket
+}
+func (c *command) setTicket(t *struct{}) {
+	c.Lock()
+	defer c.Unlock()
+
+	c.ticket = t
+}
+func (c *command) getOverflowTicket() *struct{} {
+	c.RLock()
+	defer c.RUnlock()
+
+	return c.overflowTicket
+}
+
+func (c *command) setOverflowTicket(t *struct{}) {
+	c.Lock()
+	defer c.Unlock()
+
+	c.overflowTicket = t
+}
+
+func (c *command) setRunDuration(duration time.Duration) {
+	c.Lock()
+	defer c.Unlock()
+	c.runDuration = duration
+}
+
+func (c *command) getRunDuration() time.Duration {
+	c.RLock()
+	defer c.RUnlock()
+	return c.runDuration
 }

--- a/hystrix/hystrix_bench_test.go
+++ b/hystrix/hystrix_bench_test.go
@@ -1,0 +1,38 @@
+package hystrix
+
+import (
+	"os"
+	"runtime"
+	"runtime/pprof"
+	"sync"
+	"testing"
+	"time"
+)
+
+func BenchmarkGo(b *testing.B) {
+	ConfigureCommand("bench-command", CommandConfig{
+		MaxConcurrentRequests:       1000,
+		QueueSizeRejectionThreshold: 50,
+		Timeout:                     100,
+	})
+	initialGoRoutine := runtime.NumGoroutine()
+	wg := sync.WaitGroup{}
+	wg.Add(10000)
+	for i := 0; i < 10000; i++ {
+		go func() {
+			_ = Do("bench-command", func() error {
+				time.Sleep(5 * time.Millisecond)
+				return nil
+			}, nil)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	time.Sleep(1 * time.Second)
+	finalGoRoutine := runtime.NumGoroutine()
+	// allow an approximate 10 goroutines to exist, they will soon be garbage collected
+	if finalGoRoutine-initialGoRoutine > 10 {
+		b.Fail()
+	}
+	_ = pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
+}

--- a/hystrix/metric_collector/default_metric_collector.go
+++ b/hystrix/metric_collector/default_metric_collector.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/vermapratyush/hystrix-go/hystrix/rolling"
+	"github.com/afex/hystrix-go/hystrix/rolling"
 )
 
 // DefaultMetricCollector holds information about the circuit state.

--- a/hystrix/metric_collector/metric_collector.go
+++ b/hystrix/metric_collector/metric_collector.go
@@ -45,6 +45,8 @@ func (m *metricCollectorRegistry) Register(initMetricCollector func(string) Metr
 type MetricCollector interface {
 	// IncrementAttempts increments the number of updates.
 	IncrementAttempts()
+	// IncrementQueueSize increments the number of elements in the queue.
+	IncrementQueueSize()
 	// IncrementErrors increments the number of unsuccessful attempts.
 	// Attempts minus Errors will equal successes within a time range.
 	// Errors are any result from an attempt that is not a success.

--- a/hystrix/metrics.go
+++ b/hystrix/metrics.go
@@ -4,8 +4,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/vermapratyush/hystrix-go/hystrix/metric_collector"
-	"github.com/vermapratyush/hystrix-go/hystrix/rolling"
+	"github.com/afex/hystrix-go/hystrix/metric_collector"
+	"github.com/afex/hystrix-go/hystrix/rolling"
 )
 
 type commandExecution struct {

--- a/hystrix/metrics.go
+++ b/hystrix/metrics.go
@@ -4,8 +4,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/afex/hystrix-go/hystrix/metric_collector"
-	"github.com/afex/hystrix-go/hystrix/rolling"
+	"github.com/vermapratyush/hystrix-go/hystrix/metric_collector"
+	"github.com/vermapratyush/hystrix-go/hystrix/rolling"
 )
 
 type commandExecution struct {
@@ -95,6 +95,9 @@ func (m *metricExchange) IncrementMetrics(wg *sync.WaitGroup, collector metricCo
 		collector.IncrementAttempts()
 		collector.IncrementErrors()
 	}
+	if update.Types[0] == "queued" {
+		collector.IncrementQueueSize()
+	}
 
 	if len(update.Types) > 1 {
 		// fallback metrics
@@ -140,7 +143,7 @@ func (m *metricExchange) ErrorPercent(now time.Time) int {
 	errs := m.DefaultCollector().Errors().Sum(now)
 
 	if reqs > 0 {
-		errPct = (float64(errs) / float64(reqs)) * 100
+		errPct = (errs / reqs) * 100.0
 	}
 
 	return int(errPct + 0.5)

--- a/hystrix/pool.go
+++ b/hystrix/pool.go
@@ -1,37 +1,66 @@
 package hystrix
 
-type executorPool struct {
-	Name    string
-	Metrics *poolMetrics
-	Max     int
-	Tickets chan *struct{}
+import (
+	"sync"
+)
+
+type bufferedExecutorPool struct {
+	Name                        string
+	Metrics                     *bufferedPoolMetrics
+	Max                         int
+	MaxQueueSize                int
+	QueueSizeRejectionThreshold int
+	TicketAvailableChan         chan *struct{}
+	WaitingTicket               chan *struct{}
+	Tickets                     chan *struct{}
+
+	mutex sync.Mutex
 }
 
-func newExecutorPool(name string) *executorPool {
-	p := &executorPool{}
+func newBufferedExecutorPool(name string) *bufferedExecutorPool {
+	p := &bufferedExecutorPool{}
 	p.Name = name
-	p.Metrics = newPoolMetrics(name)
+	p.mutex = sync.Mutex{}
+	p.Metrics = newBufferedPoolMetrics(name)
 	p.Max = getSettings(name).MaxConcurrentRequests
+	p.QueueSizeRejectionThreshold = getSettings(name).QueueSizeRejectionThreshold
+	p.WaitingTicket = make(chan *struct{}, p.QueueSizeRejectionThreshold)
 
 	p.Tickets = make(chan *struct{}, p.Max)
 	for i := 0; i < p.Max; i++ {
 		p.Tickets <- &struct{}{}
 	}
+	for i := 0; i < p.QueueSizeRejectionThreshold; i++ {
+		p.WaitingTicket <- &struct{}{}
+	}
 
 	return p
 }
 
-func (p *executorPool) Return(ticket *struct{}) {
+func (p *bufferedExecutorPool) Return(ticket *struct{}) {
 	if ticket == nil {
 		return
 	}
 
-	p.Metrics.Updates <- poolMetricsUpdate{
-		activeCount: p.ActiveCount(),
+	p.Metrics.Updates <- bufferedPoolMetricsUpdate{
+		activeCount:  p.ActiveCount(),
+		waitingCount: p.WaitingCount(),
 	}
 	p.Tickets <- ticket
 }
 
-func (p *executorPool) ActiveCount() int {
+func (p *bufferedExecutorPool) ReturnWaitingTicket(ticket *struct{}) {
+	if ticket == nil {
+		return
+	}
+
+	p.WaitingTicket <- ticket
+}
+
+func (p *bufferedExecutorPool) ActiveCount() int {
 	return p.Max - len(p.Tickets)
+}
+
+func (p *bufferedExecutorPool) WaitingCount() int {
+	return p.QueueSizeRejectionThreshold - len(p.WaitingTicket)
 }

--- a/hystrix/pool_metrics.go
+++ b/hystrix/pool_metrics.go
@@ -3,7 +3,7 @@ package hystrix
 import (
 	"sync"
 
-	"github.com/vermapratyush/hystrix-go/hystrix/rolling"
+	"github.com/afex/hystrix-go/hystrix/rolling"
 )
 
 type bufferedPoolMetrics struct {

--- a/hystrix/pool_test.go
+++ b/hystrix/pool_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"sync/atomic"
+
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -11,7 +13,7 @@ func TestReturn(t *testing.T) {
 	defer Flush()
 
 	Convey("when returning a ticket to the pool", t, func() {
-		pool := newExecutorPool("pool")
+		pool := newBufferedExecutorPool("pool")
 		ticket := <-pool.Tickets
 		pool.Return(ticket)
 		time.Sleep(1 * time.Millisecond)
@@ -25,7 +27,7 @@ func TestActiveCount(t *testing.T) {
 	defer Flush()
 
 	Convey("when 3 tickets are pulled", t, func() {
-		pool := newExecutorPool("pool")
+		pool := newBufferedExecutorPool("pool")
 		<-pool.Tickets
 		<-pool.Tickets
 		ticket := <-pool.Tickets
@@ -41,6 +43,115 @@ func TestActiveCount(t *testing.T) {
 				time.Sleep(1 * time.Millisecond) // allow poolMetrics to process channel
 				So(pool.Metrics.MaxActiveRequests.Max(time.Now()), ShouldEqual, 3)
 			})
+		})
+	})
+}
+
+func TestWaitingCount(t *testing.T) {
+	defer Flush()
+
+	ConfigureCommand("pool", CommandConfig{QueueSizeRejectionThreshold: 50})
+	Convey("when all execution tickets are pulled and then replenished", t, func() {
+
+		pool := newBufferedExecutorPool("pool")
+		checkpoint := make(chan struct{}, 1)
+		completedTask := int32(0)
+		// take away all pool tickets
+		for i := 0; i < pool.Max; i++ {
+			<-pool.Tickets
+		}
+		for i := 0; i < pool.QueueSizeRejectionThreshold-5; i++ {
+			<-pool.WaitingTicket
+			go func() {
+				ticket := <-pool.Tickets
+
+				if ticket != nil {
+					taskN := atomic.AddInt32(&completedTask, 1)
+					if taskN == 5 {
+						close(checkpoint)
+					}
+					pool.ReturnWaitingTicket(&struct{}{})
+				}
+			}()
+		}
+		Convey("WaitingTicket should be max-5", func() {
+			So(pool.WaitingCount(), ShouldEqual, pool.QueueSizeRejectionThreshold-5)
+		})
+
+		// return back 5 tickets
+		for i := 0; i < 5; i++ {
+			pool.Return(&struct{}{})
+		}
+
+		Convey("WaitingTicket should be max-10", func() {
+			<-checkpoint
+			So(pool.WaitingCount(), ShouldEqual, pool.QueueSizeRejectionThreshold-10)
+		})
+
+		for i := 0; i < 10; i++ {
+			<-pool.WaitingTicket
+		}
+		Convey("WaitingTicket should be max (exhausted)", func() {
+			So(pool.WaitingCount(), ShouldEqual, pool.QueueSizeRejectionThreshold)
+		})
+	})
+}
+
+func TestRefillTicket(t *testing.T) {
+	defer Flush()
+
+	ConfigureCommand("pool", CommandConfig{QueueSizeRejectionThreshold: 50})
+	Convey("when all execution tickets are pulled and then replenished twice", t, func() {
+
+		pool := newBufferedExecutorPool("pool")
+		checkpoint1 := make(chan struct{}, 1)
+		checkpoint2 := make(chan struct{}, 1)
+		completedTask := int32(0)
+
+		waitingTask := func() {
+			<-pool.WaitingTicket
+			go func() {
+				ticket := <-pool.Tickets
+				if ticket != nil {
+					taskN := atomic.AddInt32(&completedTask, 1)
+					if taskN == 5 {
+						close(checkpoint1)
+					} else if taskN == 10 {
+						close(checkpoint2)
+					}
+					pool.ReturnWaitingTicket(&struct{}{})
+				}
+			}()
+		}
+		// take away all pool tickets
+		for i := 0; i < pool.Max; i++ {
+			<-pool.Tickets
+		}
+		for i := 0; i < pool.QueueSizeRejectionThreshold; i++ {
+			waitingTask()
+		}
+		// complete 5 task
+		for i := 0; i < 5; i++ {
+			pool.Return(&struct{}{})
+		}
+		Convey("WaitingTicket should be max-5", func() {
+			<-checkpoint1
+			So(pool.ActiveCount(), ShouldEqual, pool.Max)
+			So(pool.WaitingCount(), ShouldEqual, pool.QueueSizeRejectionThreshold-5)
+		})
+
+		// take away all pool tickets again
+		for i := 0; i < 5; i++ {
+			waitingTask()
+		}
+		// complete 5 task
+		for i := 0; i < 5; i++ {
+			pool.Return(&struct{}{})
+		}
+		Convey("WaitingTicket should be max-5 again", func() {
+			<-checkpoint2
+			So(pool.ActiveCount(), ShouldEqual, pool.Max)
+			So(pool.WaitingCount(), ShouldEqual, pool.QueueSizeRejectionThreshold-5)
 		})
 	})
 }

--- a/hystrix/rolling/rolling.go
+++ b/hystrix/rolling/rolling.go
@@ -107,6 +107,7 @@ func (r *Number) Max(now time.Time) float64 {
 	return max
 }
 
+// Avg return the average value seen in the last 10 seconds.
 func (r *Number) Avg(now time.Time) float64 {
 	return r.Sum(now) / 10
 }

--- a/hystrix/rolling/rolling_timing.go
+++ b/hystrix/rolling/rolling_timing.go
@@ -44,7 +44,7 @@ func (r *Timing) SortedDurations() []time.Duration {
 	t := r.LastCachedTime
 	r.Mutex.RUnlock()
 
-	if t+time.Duration(1*time.Second).Nanoseconds() > time.Now().UnixNano() {
+	if t+time.Second.Nanoseconds() > time.Now().UnixNano() {
 		// don't recalculate if current cache is still fresh
 		return r.CachedSortedDurations
 	}

--- a/hystrix/settings.go
+++ b/hystrix/settings.go
@@ -32,11 +32,12 @@ type Settings struct {
 
 // CommandConfig is used to tune circuit settings at runtime
 type CommandConfig struct {
-	Timeout                     int `json:"timeout"`
-	MaxConcurrentRequests       int `json:"max_concurrent_requests"`
-	RequestVolumeThreshold      int `json:"request_volume_threshold"`
-	SleepWindow                 int `json:"sleep_window"`
-	ErrorPercentThreshold       int `json:"error_percent_threshold"`
+	Timeout                int `json:"timeout"`
+	MaxConcurrentRequests  int `json:"max_concurrent_requests"`
+	RequestVolumeThreshold int `json:"request_volume_threshold"`
+	SleepWindow            int `json:"sleep_window"`
+	ErrorPercentThreshold  int `json:"error_percent_threshold"`
+	// for more details refer - https://github.com/Netflix/Hystrix/wiki/Configuration#maxqueuesize
 	QueueSizeRejectionThreshold int `json:"queue_size_rejection_threshold"`
 }
 

--- a/plugins/datadog_collector.go
+++ b/plugins/datadog_collector.go
@@ -15,18 +15,19 @@ import (
 // own implemenation of DatadogClient
 const (
 	// DM = Datadog Metric
-	DM_CircuitOpen       = "hystrix.circuitOpen"
-	DM_Attempts          = "hystrix.attempts"
-	DM_Errors            = "hystrix.errors"
-	DM_Successes         = "hystrix.successes"
-	DM_Failures          = "hystrix.failures"
-	DM_Rejects           = "hystrix.rejects"
-	DM_ShortCircuits     = "hystrix.shortCircuits"
-	DM_Timeouts          = "hystrix.timeouts"
-	DM_FallbackSuccesses = "hystrix.fallbackSuccesses"
-	DM_FallbackFailures  = "hystrix.fallbackFailures"
-	DM_TotalDuration     = "hystrix.totalDuration"
-	DM_RunDuration       = "hystrix.runDuration"
+	dmCircuitOpen       = "hystrix.circuitOpen"
+	dmAttempts          = "hystrix.attempts"
+	dmQueueLength       = "hystrix.queueLength"
+	dmErrors            = "hystrix.errors"
+	dmSuccesses         = "hystrix.successes"
+	dmFailures          = "hystrix.failures"
+	dmRejects           = "hystrix.rejects"
+	dmShortCircuits     = "hystrix.shortCircuits"
+	dmTimeouts          = "hystrix.timeouts"
+	dmFallbackSuccesses = "hystrix.fallbackSuccesses"
+	dmFallbackFailures  = "hystrix.fallbackFailures"
+	dmTotalDuration     = "hystrix.totalDuration"
+	dmRunDuration       = "hystrix.runDuration"
 )
 
 type (
@@ -117,67 +118,72 @@ func NewDatadogCollectorWithClient(client DatadogClient) func(string) metricColl
 
 // IncrementAttempts increments the number of calls to this circuit.
 func (dc *DatadogCollector) IncrementAttempts() {
-	dc.client.Count(DM_Attempts, 1, dc.tags, 1.0)
+	_ = dc.client.Count(dmAttempts, 1, dc.tags, 1.0)
+}
+
+// IncrementQueueSize increments the number of elements in the queue.
+func (dc *DatadogCollector) IncrementQueueSize() {
+	_ = dc.client.Count(dmQueueLength, 1, dc.tags, 1.0)
 }
 
 // IncrementErrors increments the number of unsuccessful attempts.
 // Attempts minus Errors will equal successes within a time range.
 // Errors are any result from an attempt that is not a success.
 func (dc *DatadogCollector) IncrementErrors() {
-	dc.client.Count(DM_Errors, 1, dc.tags, 1.0)
+	_ = dc.client.Count(dmErrors, 1, dc.tags, 1.0)
 }
 
 // IncrementSuccesses increments the number of requests that succeed.
 func (dc *DatadogCollector) IncrementSuccesses() {
-	dc.client.Gauge(DM_CircuitOpen, 0, dc.tags, 1.0)
-	dc.client.Count(DM_Successes, 1, dc.tags, 1.0)
+	_ = dc.client.Gauge(dmCircuitOpen, 0, dc.tags, 1.0)
+	_ = dc.client.Count(dmSuccesses, 1, dc.tags, 1.0)
 }
 
 // IncrementFailures increments the number of requests that fail.
 func (dc *DatadogCollector) IncrementFailures() {
-	dc.client.Count(DM_Failures, 1, dc.tags, 1.0)
+	_ = dc.client.Count(dmFailures, 1, dc.tags, 1.0)
 }
 
 // IncrementRejects increments the number of requests that are rejected.
 func (dc *DatadogCollector) IncrementRejects() {
-	dc.client.Count(DM_Rejects, 1, dc.tags, 1.0)
+	_ = dc.client.Count(dmRejects, 1, dc.tags, 1.0)
 }
 
 // IncrementShortCircuits increments the number of requests that short circuited
 // due to the circuit being open.
 func (dc *DatadogCollector) IncrementShortCircuits() {
-	dc.client.Gauge(DM_CircuitOpen, 1, dc.tags, 1.0)
-	dc.client.Count(DM_ShortCircuits, 1, dc.tags, 1.0)
+	_ = dc.client.Gauge(dmCircuitOpen, 1, dc.tags, 1.0)
+	_ = dc.client.Count(dmShortCircuits, 1, dc.tags, 1.0)
 }
 
 // IncrementTimeouts increments the number of timeouts that occurred in the
 // circuit breaker.
 func (dc *DatadogCollector) IncrementTimeouts() {
-	dc.client.Count(DM_Timeouts, 1, dc.tags, 1.0)
+	_ = dc.client.Count(dmTimeouts, 1, dc.tags, 1.0)
 }
 
 // IncrementFallbackSuccesses increments the number of successes that occurred
 // during the execution of the fallback function.
 func (dc *DatadogCollector) IncrementFallbackSuccesses() {
-	dc.client.Count(DM_FallbackSuccesses, 1, dc.tags, 1.0)
+	_ = dc.client.Count(dmFallbackSuccesses, 1, dc.tags, 1.0)
 }
 
 // IncrementFallbackFailures increments the number of failures that occurred
 // during the execution of the fallback function.
 func (dc *DatadogCollector) IncrementFallbackFailures() {
-	dc.client.Count(DM_FallbackFailures, 1, dc.tags, 1.0)
+	_ = dc.client.Count(dmFallbackFailures, 1, dc.tags, 1.0)
 }
 
 // UpdateTotalDuration updates the internal counter of how long we've run for.
 func (dc *DatadogCollector) UpdateTotalDuration(timeSinceStart time.Duration) {
 	ms := float64(timeSinceStart.Nanoseconds() / 1000000)
-	dc.client.TimeInMilliseconds(DM_TotalDuration, ms, dc.tags, 1.0)
+	_ = dc.client.TimeInMilliseconds(dmTotalDuration, ms, dc.tags, 1.0)
 }
 
 // UpdateRunDuration updates the internal counter of how long the last run took.
 func (dc *DatadogCollector) UpdateRunDuration(runDuration time.Duration) {
 	ms := float64(runDuration.Nanoseconds() / 1000000)
-	dc.client.TimeInMilliseconds(DM_RunDuration, ms, dc.tags, 1.0)
+	_ = dc.client.TimeInMilliseconds(dmRunDuration, ms, dc.tags, 1.0)
 }
 
 // Reset is a noop operation in this collector.


### PR DESCRIPTION
Adds a buffer on requests before throwing ErrMaxConcurrency.
The Timeout is still adhered to, timer starts when the request is submitted to hystrix-go, not when execution starts. This basically implements MaxQueueSize as present in the [Netflix's Hystrix](https://github.com/Netflix/Hystrix/wiki/Configuration#maxqueuesize)

The default value of `MaxQueueSize is 50 (5 * MaxConcurrency)`, although can be overridden when initialising circuit.

In addition to the request buffer, the PR includes a different way to solving for #67 . It uses channels instead of `sync.Once`. Also some go-lint fixes.

We have been running this in production at Grab for a while, and there seems to be no side effects.