### PR TITLE
Remove usage of package "log"

### DIFF
--- a/hystrix/hystrix.go
+++ b/hystrix/hystrix.go
@@ -2,7 +2,6 @@ package hystrix
 
 import (
 	"fmt"
-	"log"
 	"sync"
 	"time"
 )
@@ -89,7 +88,7 @@ func Go(name string, run runFunc, fallback fallbackFunc) chan error {
 	reportAllEvent := func() {
 		err := cmd.circuit.ReportEvent(cmd.events, cmd.start, cmd.runDuration)
 		if err != nil {
-			log.Print(err)
+			cmd.circuit.logger.Printf("%v", err)
 		}
 	}
 

--- a/hystrix/logger.go
+++ b/hystrix/logger.go
@@ -1,0 +1,11 @@
+package hystrix
+
+type logger interface {
+	Printf(format string, items ...interface{})
+}
+
+// NoopLogger does not log anything.
+type NoopLogger struct{}
+
+// Printf does nothing.
+func (l NoopLogger) Printf(format string, items ...interface{}) {}

--- a/hystrix/settings.go
+++ b/hystrix/settings.go
@@ -16,6 +16,8 @@ var (
 	DefaultSleepWindow = 5000
 	// DefaultErrorPercentThreshold causes circuits to open once the rolling measure of errors exceeds this percent of requests
 	DefaultErrorPercentThreshold = 50
+	// DefaultLogger does not log anything.
+	DefaultLogger = NoopLogger{}
 )
 
 type Settings struct {
@@ -24,6 +26,7 @@ type Settings struct {
 	RequestVolumeThreshold uint64
 	SleepWindow            time.Duration
 	ErrorPercentThreshold  int
+	Logger                 logger
 }
 
 // CommandConfig is used to tune circuit settings at runtime
@@ -33,6 +36,7 @@ type CommandConfig struct {
 	RequestVolumeThreshold int `json:"request_volume_threshold"`
 	SleepWindow            int `json:"sleep_window"`
 	ErrorPercentThreshold  int `json:"error_percent_threshold"`
+	Logger                 logger
 }
 
 var circuitSettings map[string]*Settings
@@ -80,12 +84,18 @@ func ConfigureCommand(name string, config CommandConfig) {
 		errorPercent = config.ErrorPercentThreshold
 	}
 
+	var l logger = DefaultLogger
+	if config.Logger != nil {
+		l = config.Logger
+	}
+
 	circuitSettings[name] = &Settings{
 		Timeout:                time.Duration(timeout) * time.Millisecond,
 		MaxConcurrentRequests:  max,
 		RequestVolumeThreshold: uint64(volume),
 		SleepWindow:            time.Duration(sleep) * time.Millisecond,
 		ErrorPercentThreshold:  errorPercent,
+		Logger:                 l,
 	}
 }
 


### PR DESCRIPTION
This change replaces usages of package "log" with a logger interface.
The interface is minimal--only a Printf() method is exposed.

The interface encourages loose coupling and allows consumers to configure the use of their own logger.