### PR TITLE
Treat bad requests separately from other errors

### DIFF
--- a/hystrix/hystrix.go
+++ b/hystrix/hystrix.go
@@ -267,12 +267,11 @@ func (c *command) tryFallback(err error) error {
 	}
 
 	fallbackErr := c.fallback(err)
-	if fallbackErr != nil {
-		c.reportEvent("fallback-failure")
-		return fmt.Errorf("fallback failed with '%v'. run error was '%v'", fallbackErr, err)
+	if _, ok := fallbackErr.(BadRequest); ok || fallbackErr == nil {
+		c.reportEvent("fallback-success")
+		return fallbackErr
 	}
 
-	c.reportEvent("fallback-success")
-
-	return nil
+	c.reportEvent("fallback-failure")
+	return fmt.Errorf("fallback failed with '%v'. run error was '%v'", fallbackErr, err)
 }

--- a/hystrix/hystrix_test.go
+++ b/hystrix/hystrix_test.go
@@ -88,12 +88,11 @@ func TestBadRequest(t *testing.T) {
 			So(<-resultChan, ShouldEqual, 1)
 
 			Convey("an error should have been returned", func() {
-				So(len(errChan), ShouldEqual, 1)
 				err := <-errChan
-				br, ok := err.(BadRequest)
+				So(err, ShouldNotBeNil)
+				_, ok := err.(BadRequest)
 				Convey("it should be a bad request", func() {
 					So(ok, ShouldBeTrue)
-					So(br, ShouldNotBeNil)
 				})
 			})
 			Convey("fallback should not have been called", func() {
@@ -134,12 +133,11 @@ func TestBadRequestInFallback(t *testing.T) {
 			So(<-resultChan, ShouldEqual, 1)
 
 			Convey("an error should have been returned", func() {
-				So(len(errChan), ShouldEqual, 1)
 				err := <-errChan
-				br, ok := err.(BadRequest)
+				So(err, ShouldNotBeNil)
+				_, ok := err.(BadRequest)
 				Convey("it should be a bad request", func() {
 					So(ok, ShouldBeTrue)
-					So(br, ShouldNotBeNil)
 				})
 			})
 			Convey("metrics have been recorded properly", func() {


### PR DESCRIPTION
Adding special error type that will be treated as a successful request

See: https://github.com/afex/hystrix-go/issues/72