### PR TITLE
simplify MetricCollector interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ go:
   - 1.6.x
   - 1.7.x
   - 1.8.x
+  - 1.9.x
   - tip
 env:
   global:

--- a/hystrix/metric_collector/default_metric_collector.go
+++ b/hystrix/metric_collector/default_metric_collector.go
@@ -2,7 +2,6 @@ package metricCollector
 
 import (
 	"sync"
-	"time"
 
 	"github.com/afex/hystrix-go/hystrix/rolling"
 )
@@ -115,82 +114,22 @@ func (d *DefaultMetricCollector) RunDuration() *rolling.Timing {
 	return d.runDuration
 }
 
-// IncrementAttempts increments the number of requests seen in the latest time bucket.
-func (d *DefaultMetricCollector) IncrementAttempts() {
+func (d *DefaultMetricCollector) Update(r MetricResult) {
 	d.mutex.RLock()
 	defer d.mutex.RUnlock()
-	d.numRequests.Increment(1)
-}
 
-// IncrementErrors increments the number of errors seen in the latest time bucket.
-// Errors are any result from an attempt that is not a success.
-func (d *DefaultMetricCollector) IncrementErrors() {
-	d.mutex.RLock()
-	defer d.mutex.RUnlock()
-	d.errors.Increment(1)
-}
+	d.numRequests.Increment(r.Attempts)
+	d.errors.Increment(r.Errors)
+	d.successes.Increment(r.Successes)
+	d.failures.Increment(r.Failures)
+	d.rejects.Increment(r.Rejects)
+	d.shortCircuits.Increment(r.ShortCircuits)
+	d.timeouts.Increment(r.Timeouts)
+	d.fallbackSuccesses.Increment(r.FallbackSuccesses)
+	d.fallbackFailures.Increment(r.FallbackFailures)
 
-// IncrementSuccesses increments the number of successes seen in the latest time bucket.
-func (d *DefaultMetricCollector) IncrementSuccesses() {
-	d.mutex.RLock()
-	defer d.mutex.RUnlock()
-	d.successes.Increment(1)
-}
-
-// IncrementFailures increments the number of failures seen in the latest time bucket.
-func (d *DefaultMetricCollector) IncrementFailures() {
-	d.mutex.RLock()
-	defer d.mutex.RUnlock()
-	d.failures.Increment(1)
-}
-
-// IncrementRejects increments the number of rejected requests seen in the latest time bucket.
-func (d *DefaultMetricCollector) IncrementRejects() {
-	d.mutex.RLock()
-	defer d.mutex.RUnlock()
-	d.rejects.Increment(1)
-}
-
-// IncrementShortCircuits increments the number of rejected requests seen in the latest time bucket.
-func (d *DefaultMetricCollector) IncrementShortCircuits() {
-	d.mutex.RLock()
-	defer d.mutex.RUnlock()
-	d.shortCircuits.Increment(1)
-}
-
-// IncrementTimeouts increments the number of requests that timed out in the latest time bucket.
-func (d *DefaultMetricCollector) IncrementTimeouts() {
-	d.mutex.RLock()
-	defer d.mutex.RUnlock()
-	d.timeouts.Increment(1)
-}
-
-// IncrementFallbackSuccesses increments the number of successful calls to the fallback function in the latest time bucket.
-func (d *DefaultMetricCollector) IncrementFallbackSuccesses() {
-	d.mutex.RLock()
-	defer d.mutex.RUnlock()
-	d.fallbackSuccesses.Increment(1)
-}
-
-// IncrementFallbackFailures increments the number of failed calls to the fallback function in the latest time bucket.
-func (d *DefaultMetricCollector) IncrementFallbackFailures() {
-	d.mutex.RLock()
-	defer d.mutex.RUnlock()
-	d.fallbackFailures.Increment(1)
-}
-
-// UpdateTotalDuration updates the total amount of time this circuit has been running.
-func (d *DefaultMetricCollector) UpdateTotalDuration(timeSinceStart time.Duration) {
-	d.mutex.RLock()
-	defer d.mutex.RUnlock()
-	d.totalDuration.Add(timeSinceStart)
-}
-
-// UpdateRunDuration updates the amount of time the latest request took to complete.
-func (d *DefaultMetricCollector) UpdateRunDuration(runDuration time.Duration) {
-	d.mutex.RLock()
-	defer d.mutex.RUnlock()
-	d.runDuration.Add(runDuration)
+	d.totalDuration.Add(r.TotalDuration)
+	d.runDuration.Add(r.RunDuration)
 }
 
 // Reset resets all metrics in this collector to 0.

--- a/hystrix/metric_collector/metric_collector.go
+++ b/hystrix/metric_collector/metric_collector.go
@@ -39,34 +39,26 @@ func (m *metricCollectorRegistry) Register(initMetricCollector func(string) Metr
 	m.registry = append(m.registry, initMetricCollector)
 }
 
+type MetricResult struct {
+	Attempts          float64
+	Errors            float64
+	Successes         float64
+	Failures          float64
+	Rejects           float64
+	ShortCircuits     float64
+	Timeouts          float64
+	FallbackSuccesses float64
+	FallbackFailures  float64
+	TotalDuration     time.Duration
+	RunDuration       time.Duration
+}
+
 // MetricCollector represents the contract that all collectors must fulfill to gather circuit statistics.
 // Implementations of this interface do not have to maintain locking around thier data stores so long as
 // they are not modified outside of the hystrix context.
 type MetricCollector interface {
-	// IncrementAttempts increments the number of updates.
-	IncrementAttempts()
-	// IncrementErrors increments the number of unsuccessful attempts.
-	// Attempts minus Errors will equal successes within a time range.
-	// Errors are any result from an attempt that is not a success.
-	IncrementErrors()
-	// IncrementSuccesses increments the number of requests that succeed.
-	IncrementSuccesses()
-	// IncrementFailures increments the number of requests that fail.
-	IncrementFailures()
-	// IncrementRejects increments the number of requests that are rejected.
-	IncrementRejects()
-	// IncrementShortCircuits increments the number of requests that short circuited due to the circuit being open.
-	IncrementShortCircuits()
-	// IncrementTimeouts increments the number of timeouts that occurred in the circuit breaker.
-	IncrementTimeouts()
-	// IncrementFallbackSuccesses increments the number of successes that occurred during the execution of the fallback function.
-	IncrementFallbackSuccesses()
-	// IncrementFallbackFailures increments the number of failures that occurred during the execution of the fallback function.
-	IncrementFallbackFailures()
-	// UpdateTotalDuration updates the internal counter of how long we've run for.
-	UpdateTotalDuration(timeSinceStart time.Duration)
-	// UpdateRunDuration updates the internal counter of how long the last run took.
-	UpdateRunDuration(runDuration time.Duration)
+	// Update accepts a set of metrics from a command execution for remote instrumentation
+	Update(MetricResult)
 	// Reset resets the internal counters and timers.
 	Reset()
 }

--- a/hystrix/metrics.go
+++ b/hystrix/metrics.go
@@ -67,47 +67,43 @@ func (m *metricExchange) Monitor() {
 
 func (m *metricExchange) IncrementMetrics(wg *sync.WaitGroup, collector metricCollector.MetricCollector, update *commandExecution, totalDuration time.Duration) {
 	// granular metrics
+	r := metricCollector.MetricResult{
+		Attempts:      1,
+		TotalDuration: totalDuration,
+		RunDuration:   update.RunDuration,
+	}
+
 	if update.Types[0] == "success" {
-		collector.IncrementAttempts()
-		collector.IncrementSuccesses()
+		r.Successes = 1
 	}
 	if update.Types[0] == "failure" {
-		collector.IncrementFailures()
-
-		collector.IncrementAttempts()
-		collector.IncrementErrors()
+		r.Failures = 1
+		r.Errors = 1
 	}
 	if update.Types[0] == "rejected" {
-		collector.IncrementRejects()
-
-		collector.IncrementAttempts()
-		collector.IncrementErrors()
+		r.Rejects = 1
+		r.Errors = 1
 	}
 	if update.Types[0] == "short-circuit" {
-		collector.IncrementShortCircuits()
-
-		collector.IncrementAttempts()
-		collector.IncrementErrors()
+		r.ShortCircuits = 1
+		r.Errors = 1
 	}
 	if update.Types[0] == "timeout" {
-		collector.IncrementTimeouts()
-
-		collector.IncrementAttempts()
-		collector.IncrementErrors()
+		r.Timeouts = 1
+		r.Errors = 1
 	}
 
 	if len(update.Types) > 1 {
 		// fallback metrics
 		if update.Types[1] == "fallback-success" {
-			collector.IncrementFallbackSuccesses()
+			r.FallbackSuccesses = 1
 		}
 		if update.Types[1] == "fallback-failure" {
-			collector.IncrementFallbackFailures()
+			r.FallbackFailures = 1
 		}
 	}
 
-	collector.UpdateTotalDuration(totalDuration)
-	collector.UpdateRunDuration(update.RunDuration)
+	collector.Update(r)
 
 	wg.Done()
 }

--- a/hystrix/rolling/rolling.go
+++ b/hystrix/rolling/rolling.go
@@ -51,6 +51,10 @@ func (r *Number) removeOldBuckets() {
 
 // Increment increments the number in current timeBucket.
 func (r *Number) Increment(i float64) {
+	if i == 0 {
+		return
+	}
+
 	r.Mutex.Lock()
 	defer r.Mutex.Unlock()
 

--- a/plugins/graphite_aggregator.go
+++ b/plugins/graphite_aggregator.go
@@ -72,12 +72,15 @@ func NewGraphiteCollector(name string) metricCollector.MetricCollector {
 	}
 }
 
-func (g *GraphiteCollector) incrementCounterMetric(prefix string) {
+func (g *GraphiteCollector) incrementCounterMetric(prefix string, i float64) {
+	if i == 0 {
+		return
+	}
 	c, ok := metrics.GetOrRegister(prefix, makeCounterFunc).(metrics.Counter)
 	if !ok {
 		return
 	}
-	c.Inc(1)
+	c.Inc(int64(i))
 }
 
 func (g *GraphiteCollector) updateTimerMetric(prefix string, dur time.Duration) {
@@ -88,74 +91,18 @@ func (g *GraphiteCollector) updateTimerMetric(prefix string, dur time.Duration) 
 	c.Update(dur)
 }
 
-// IncrementAttempts increments the number of calls to this circuit.
-// This registers as a counter in the graphite collector.
-func (g *GraphiteCollector) IncrementAttempts() {
-	g.incrementCounterMetric(g.attemptsPrefix)
-}
-
-// IncrementErrors increments the number of unsuccessful attempts.
-// Attempts minus Errors will equal successes within a time range.
-// Errors are any result from an attempt that is not a success.
-// This registers as a counter in the graphite collector.
-func (g *GraphiteCollector) IncrementErrors() {
-	g.incrementCounterMetric(g.errorsPrefix)
-
-}
-
-// IncrementSuccesses increments the number of requests that succeed.
-// This registers as a counter in the graphite collector.
-func (g *GraphiteCollector) IncrementSuccesses() {
-	g.incrementCounterMetric(g.successesPrefix)
-
-}
-
-// IncrementFailures increments the number of requests that fail.
-// This registers as a counter in the graphite collector.
-func (g *GraphiteCollector) IncrementFailures() {
-	g.incrementCounterMetric(g.failuresPrefix)
-}
-
-// IncrementRejects increments the number of requests that are rejected.
-// This registers as a counter in the graphite collector.
-func (g *GraphiteCollector) IncrementRejects() {
-	g.incrementCounterMetric(g.rejectsPrefix)
-}
-
-// IncrementShortCircuits increments the number of requests that short circuited due to the circuit being open.
-// This registers as a counter in the graphite collector.
-func (g *GraphiteCollector) IncrementShortCircuits() {
-	g.incrementCounterMetric(g.shortCircuitsPrefix)
-}
-
-// IncrementTimeouts increments the number of timeouts that occurred in the circuit breaker.
-// This registers as a counter in the graphite collector.
-func (g *GraphiteCollector) IncrementTimeouts() {
-	g.incrementCounterMetric(g.timeoutsPrefix)
-}
-
-// IncrementFallbackSuccesses increments the number of successes that occurred during the execution of the fallback function.
-// This registers as a counter in the graphite collector.
-func (g *GraphiteCollector) IncrementFallbackSuccesses() {
-	g.incrementCounterMetric(g.fallbackSuccessesPrefix)
-}
-
-// IncrementFallbackFailures increments the number of failures that occurred during the execution of the fallback function.
-// This registers as a counter in the graphite collector.
-func (g *GraphiteCollector) IncrementFallbackFailures() {
-	g.incrementCounterMetric(g.fallbackFailuresPrefix)
-}
-
-// UpdateTotalDuration updates the internal counter of how long we've run for.
-// This registers as a timer in the graphite collector.
-func (g *GraphiteCollector) UpdateTotalDuration(timeSinceStart time.Duration) {
-	g.updateTimerMetric(g.totalDurationPrefix, timeSinceStart)
-}
-
-// UpdateRunDuration updates the internal counter of how long the last run took.
-// This registers as a timer in the graphite collector.
-func (g *GraphiteCollector) UpdateRunDuration(runDuration time.Duration) {
-	g.updateTimerMetric(g.runDurationPrefix, runDuration)
+func (g *GraphiteCollector) Update(r metricCollector.MetricResult) {
+	g.incrementCounterMetric(g.attemptsPrefix, r.Attempts)
+	g.incrementCounterMetric(g.errorsPrefix, r.Errors)
+	g.incrementCounterMetric(g.successesPrefix, r.Successes)
+	g.incrementCounterMetric(g.failuresPrefix, r.Failures)
+	g.incrementCounterMetric(g.rejectsPrefix, r.Rejects)
+	g.incrementCounterMetric(g.shortCircuitsPrefix, r.ShortCircuits)
+	g.incrementCounterMetric(g.timeoutsPrefix, r.Timeouts)
+	g.incrementCounterMetric(g.fallbackSuccessesPrefix, r.FallbackSuccesses)
+	g.incrementCounterMetric(g.fallbackFailuresPrefix, r.FallbackFailures)
+	g.updateTimerMetric(g.totalDurationPrefix, r.TotalDuration)
+	g.updateTimerMetric(g.runDurationPrefix, r.RunDuration)
 }
 
 // Reset is a noop operation in this collector.

--- a/plugins/statsd_collector.go
+++ b/plugins/statsd_collector.go
@@ -116,8 +116,8 @@ func (g *StatsdCollector) setGauge(prefix string, value int64) {
 	}
 }
 
-func (g *StatsdCollector) incrementCounterMetric(prefix string) {
-	err := g.client.Inc(prefix, 1, g.sampleRate)
+func (g *StatsdCollector) incrementCounterMetric(prefix string, i float64) {
+	err := g.client.Inc(prefix, int64(i), g.sampleRate)
 	if err != nil {
 		log.Printf("Error sending statsd metrics %s", prefix)
 	}
@@ -130,76 +130,24 @@ func (g *StatsdCollector) updateTimerMetric(prefix string, dur time.Duration) {
 	}
 }
 
-// IncrementAttempts increments the number of calls to this circuit.
-// This registers as a counter in the Statsd collector.
-func (g *StatsdCollector) IncrementAttempts() {
-	g.incrementCounterMetric(g.attemptsPrefix)
-}
+func (g *StatsdCollector) Update(r metricCollector.MetricResult) {
+	if r.Successes > 0 {
+		g.setGauge(g.circuitOpenPrefix, 0)
+	} else if r.ShortCircuits > 0 {
+		g.setGauge(g.circuitOpenPrefix, 1)
+	}
 
-// IncrementErrors increments the number of unsuccessful attempts.
-// Attempts minus Errors will equal successes within a time range.
-// Errors are any result from an attempt that is not a success.
-// This registers as a counter in the Statsd collector.
-func (g *StatsdCollector) IncrementErrors() {
-	g.incrementCounterMetric(g.errorsPrefix)
-
-}
-
-// IncrementSuccesses increments the number of requests that succeed.
-// This registers as a counter in the Statsd collector.
-func (g *StatsdCollector) IncrementSuccesses() {
-	g.setGauge(g.circuitOpenPrefix, 0)
-	g.incrementCounterMetric(g.successesPrefix)
-
-}
-
-// IncrementFailures increments the number of requests that fail.
-// This registers as a counter in the Statsd collector.
-func (g *StatsdCollector) IncrementFailures() {
-	g.incrementCounterMetric(g.failuresPrefix)
-}
-
-// IncrementRejects increments the number of requests that are rejected.
-// This registers as a counter in the Statsd collector.
-func (g *StatsdCollector) IncrementRejects() {
-	g.incrementCounterMetric(g.rejectsPrefix)
-}
-
-// IncrementShortCircuits increments the number of requests that short circuited due to the circuit being open.
-// This registers as a counter in the Statsd collector.
-func (g *StatsdCollector) IncrementShortCircuits() {
-	g.setGauge(g.circuitOpenPrefix, 1)
-	g.incrementCounterMetric(g.shortCircuitsPrefix)
-}
-
-// IncrementTimeouts increments the number of timeouts that occurred in the circuit breaker.
-// This registers as a counter in the Statsd collector.
-func (g *StatsdCollector) IncrementTimeouts() {
-	g.incrementCounterMetric(g.timeoutsPrefix)
-}
-
-// IncrementFallbackSuccesses increments the number of successes that occurred during the execution of the fallback function.
-// This registers as a counter in the Statsd collector.
-func (g *StatsdCollector) IncrementFallbackSuccesses() {
-	g.incrementCounterMetric(g.fallbackSuccessesPrefix)
-}
-
-// IncrementFallbackFailures increments the number of failures that occurred during the execution of the fallback function.
-// This registers as a counter in the Statsd collector.
-func (g *StatsdCollector) IncrementFallbackFailures() {
-	g.incrementCounterMetric(g.fallbackFailuresPrefix)
-}
-
-// UpdateTotalDuration updates the internal counter of how long we've run for.
-// This registers as a timer in the Statsd collector.
-func (g *StatsdCollector) UpdateTotalDuration(timeSinceStart time.Duration) {
-	g.updateTimerMetric(g.totalDurationPrefix, timeSinceStart)
-}
-
-// UpdateRunDuration updates the internal counter of how long the last run took.
-// This registers as a timer in the Statsd collector.
-func (g *StatsdCollector) UpdateRunDuration(runDuration time.Duration) {
-	g.updateTimerMetric(g.runDurationPrefix, runDuration)
+	g.incrementCounterMetric(g.attemptsPrefix, r.Attempts)
+	g.incrementCounterMetric(g.errorsPrefix, r.Errors)
+	g.incrementCounterMetric(g.successesPrefix, r.Successes)
+	g.incrementCounterMetric(g.failuresPrefix, r.Failures)
+	g.incrementCounterMetric(g.rejectsPrefix, r.Rejects)
+	g.incrementCounterMetric(g.shortCircuitsPrefix, r.ShortCircuits)
+	g.incrementCounterMetric(g.timeoutsPrefix, r.Timeouts)
+	g.incrementCounterMetric(g.fallbackSuccessesPrefix, r.FallbackSuccesses)
+	g.incrementCounterMetric(g.fallbackFailuresPrefix, r.FallbackFailures)
+	g.updateTimerMetric(g.totalDurationPrefix, r.TotalDuration)
+	g.updateTimerMetric(g.runDurationPrefix, r.RunDuration)
 }
 
 // Reset is a noop operation in this collector.

--- a/scripts/vagrant.sh
+++ b/scripts/vagrant.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-wget -q https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz
-tar -C /usr/local -xzf go1.6.2.linux-amd64.tar.gz
+wget -q https://storage.googleapis.com/golang/go1.9.4.linux-amd64.tar.gz
+tar -C /usr/local -xzf go1.9.4.linux-amd64.tar.gz
 
 apt-get update
 apt-get -y install git mercurial apache2-utils
@@ -20,3 +20,5 @@ go get github.com/rcrowley/go-metrics
 go get github.com/DataDog/datadog-go/statsd
 
 chown -R vagrant:vagrant /go
+
+echo "cd /go/src/github.com/afex/hystrix-go" >> /home/vagrant/.bashrc


### PR DESCRIPTION
replace all update functions with a single one which accepts a struct. this should make it easier for future features to add new counters and timers without needing interface changes