### PR TITLE
[README] Updated Hystrix dashboard url

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ You can also use ```hystrix.Configure()``` which accepts a ```map[string]Command
 
 ### Enable dashboard metrics
 
-In your main.go, register the event stream HTTP handler on a port and launch it in a goroutine.  Once you configure turbine for your [Hystrix Dashboard](https://github.com/Netflix/Hystrix/tree/master/hystrix-dashboard) to start streaming events, your commands will automatically begin appearing.
+In your main.go, register the event stream HTTP handler on a port and launch it in a goroutine.  Once you configure turbine for your [Hystrix Dashboard](https://github.com/Netflix-Skunkworks/hystrix-dashboard) to start streaming events, your commands will automatically begin appearing.
 
 ```go
 hystrixStreamHandler := hystrix.NewStreamHandler()


### PR DESCRIPTION
Hystrix dashboard now deprecated and moved to Netflix-skunkworks repo so i updated url.

https://github.com/Netflix/Hystrix/commit/1ee6ae235b257f085056ed5ab5e54a53d81e07e0