### PR TITLE
Remove 'log' package usage. Allows for specifying a custom logger.

### DIFF
--- a/hystrix/circuit.go
+++ b/hystrix/circuit.go
@@ -127,7 +127,7 @@ func (circuit *CircuitBreaker) allowSingleTest() bool {
 	if circuit.open && now > openedOrLastTestedTime+getSettings(circuit.Name).SleepWindow.Nanoseconds() {
 		swapped := atomic.CompareAndSwapInt64(&circuit.openedOrLastTestedTime, openedOrLastTestedTime, now)
 		if swapped {
-			logger.Printf("hystrix-go: allowing single test to possibly close circuit %v", circuit.Name)
+			log.Printf("hystrix-go: allowing single test to possibly close circuit %v", circuit.Name)
 		}
 		return swapped
 	}
@@ -143,7 +143,7 @@ func (circuit *CircuitBreaker) setOpen() {
 		return
 	}
 
-	logger.Printf("hystrix-go: opening circuit %v", circuit.Name)
+	log.Printf("hystrix-go: opening circuit %v", circuit.Name)
 
 	circuit.openedOrLastTestedTime = time.Now().UnixNano()
 	circuit.open = true
@@ -157,7 +157,7 @@ func (circuit *CircuitBreaker) setClose() {
 		return
 	}
 
-	logger.Printf("hystrix-go: closing circuit %v", circuit.Name)
+	log.Printf("hystrix-go: closing circuit %v", circuit.Name)
 
 	circuit.open = false
 	circuit.metrics.Reset()

--- a/hystrix/circuit.go
+++ b/hystrix/circuit.go
@@ -18,8 +18,6 @@ type CircuitBreaker struct {
 
 	executorPool *executorPool
 	metrics      *metricExchange
-
-	customLogger logger
 }
 
 var (
@@ -129,7 +127,7 @@ func (circuit *CircuitBreaker) allowSingleTest() bool {
 	if circuit.open && now > openedOrLastTestedTime+getSettings(circuit.Name).SleepWindow.Nanoseconds() {
 		swapped := atomic.CompareAndSwapInt64(&circuit.openedOrLastTestedTime, openedOrLastTestedTime, now)
 		if swapped {
-			circuit.log("hystrix-go: allowing single test to possibly close circuit %v", circuit.Name)
+			logger.Printf("hystrix-go: allowing single test to possibly close circuit %v", circuit.Name)
 		}
 		return swapped
 	}
@@ -145,7 +143,7 @@ func (circuit *CircuitBreaker) setOpen() {
 		return
 	}
 
-	circuit.log("hystrix-go: opening circuit %v", circuit.Name)
+	logger.Printf("hystrix-go: opening circuit %v", circuit.Name)
 
 	circuit.openedOrLastTestedTime = time.Now().UnixNano()
 	circuit.open = true
@@ -159,7 +157,7 @@ func (circuit *CircuitBreaker) setClose() {
 		return
 	}
 
-	circuit.log("hystrix-go: closing circuit %v", circuit.Name)
+	logger.Printf("hystrix-go: closing circuit %v", circuit.Name)
 
 	circuit.open = false
 	circuit.metrics.Reset()
@@ -189,16 +187,4 @@ func (circuit *CircuitBreaker) ReportEvent(eventTypes []string, start time.Time,
 	}
 
 	return nil
-}
-
-func (circuit *CircuitBreaker) WithLogger(l logger) {
-	circuit.customLogger = l
-}
-
-func (circuit *CircuitBreaker) log(format string, items ...interface{}) {
-	if circuit.customLogger != nil {
-		circuit.customLogger.Printf(format, items...)
-	} else {
-		logger.Printf(format, items...)
-	}
 }

--- a/hystrix/hystrix.go
+++ b/hystrix/hystrix.go
@@ -3,7 +3,6 @@ package hystrix
 import (
 	"context"
 	"fmt"
-	"log"
 	"sync"
 	"time"
 )
@@ -110,7 +109,7 @@ func GoC(ctx context.Context, name string, run runFuncC, fallback fallbackFuncC)
 	reportAllEvent := func() {
 		err := cmd.circuit.ReportEvent(cmd.events, cmd.start, cmd.runDuration)
 		if err != nil {
-			log.Print(err)
+			logger.Printf(err)
 		}
 	}
 

--- a/hystrix/hystrix.go
+++ b/hystrix/hystrix.go
@@ -109,7 +109,7 @@ func GoC(ctx context.Context, name string, run runFuncC, fallback fallbackFuncC)
 	reportAllEvent := func() {
 		err := cmd.circuit.ReportEvent(cmd.events, cmd.start, cmd.runDuration)
 		if err != nil {
-			logger.Printf(err)
+			log.Printf(err.Error())
 		}
 	}
 

--- a/hystrix/logger.go
+++ b/hystrix/logger.go
@@ -1,0 +1,11 @@
+package hystrix
+
+type logger interface {
+	Printf(format string, items ...interface{})
+}
+
+// NoopLogger does not log anything.
+type NoopLogger struct{}
+
+// Printf does nothing.
+func (l NoopLogger) Printf(format string, items ...interface{}) {}

--- a/hystrix/settings.go
+++ b/hystrix/settings.go
@@ -37,6 +37,7 @@ type CommandConfig struct {
 
 var circuitSettings map[string]*Settings
 var settingsMutex *sync.RWMutex
+var logger logger
 
 func init() {
 	circuitSettings = make(map[string]*Settings)
@@ -112,4 +113,8 @@ func GetCircuitSettings() map[string]*Settings {
 	settingsMutex.RUnlock()
 
 	return copy
+}
+
+func SetDefaultLogger(l logger) {
+	logger = l
 }

--- a/hystrix/settings.go
+++ b/hystrix/settings.go
@@ -118,7 +118,7 @@ func GetCircuitSettings() map[string]*Settings {
 	return copy
 }
 
-// SetLogger configures the logger that will be used.
+// SetLogger configures the logger that will be used. This only applies to the hystrix package.
 func SetLogger(l logger) {
 	logger = l
 }

--- a/hystrix/settings.go
+++ b/hystrix/settings.go
@@ -16,6 +16,8 @@ var (
 	DefaultSleepWindow = 5000
 	// DefaultErrorPercentThreshold causes circuits to open once the rolling measure of errors exceeds this percent of requests
 	DefaultErrorPercentThreshold = 50
+	// DefaultLogger is the default logger that will be used in the Hystrix package. By default prints nothing.
+	DefaultLogger = NoopLogger{}
 )
 
 type Settings struct {
@@ -42,6 +44,7 @@ var logger logger
 func init() {
 	circuitSettings = make(map[string]*Settings)
 	settingsMutex = &sync.RWMutex{}
+	logger = DefaultLogger
 }
 
 // Configure applies settings for a set of circuits

--- a/hystrix/settings.go
+++ b/hystrix/settings.go
@@ -39,12 +39,12 @@ type CommandConfig struct {
 
 var circuitSettings map[string]*Settings
 var settingsMutex *sync.RWMutex
-var logger logger
+var log logger
 
 func init() {
 	circuitSettings = make(map[string]*Settings)
 	settingsMutex = &sync.RWMutex{}
-	logger = DefaultLogger
+	log = DefaultLogger
 }
 
 // Configure applies settings for a set of circuits
@@ -120,5 +120,5 @@ func GetCircuitSettings() map[string]*Settings {
 
 // SetLogger configures the logger that will be used. This only applies to the hystrix package.
 func SetLogger(l logger) {
-	logger = l
+	log = l
 }

--- a/hystrix/settings.go
+++ b/hystrix/settings.go
@@ -118,6 +118,7 @@ func GetCircuitSettings() map[string]*Settings {
 	return copy
 }
 
-func SetDefaultLogger(l logger) {
+// SetLogger configures the logger that will be used.
+func SetLogger(l logger) {
 	logger = l
 }


### PR DESCRIPTION
Similar to https://github.com/afex/hystrix-go/pull/76, but configuring the logger once for the entire package, instead of tying the logger to the circuits.