### PR TITLE
Expose concurrencyInUse

### DIFF
--- a/hystrix/circuit_test.go
+++ b/hystrix/circuit_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/smartystreets/goconvey/convey"
-	"testing/quick"
 	"math/rand"
+	"testing/quick"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestGetCircuit(t *testing.T) {
@@ -103,10 +104,10 @@ func TestReportEventMultiThreaded(t *testing.T) {
 		defer Flush()
 		// Make the circuit easily open and close intermittently.
 		ConfigureCommand("", CommandConfig{
-			MaxConcurrentRequests: 1,
-			ErrorPercentThreshold: 1,
+			MaxConcurrentRequests:  1,
+			ErrorPercentThreshold:  1,
 			RequestVolumeThreshold: 1,
-			SleepWindow: 10,
+			SleepWindow:            10,
 		})
 		cb, _, _ := GetCircuit("")
 		count := 5

--- a/hystrix/metric_collector/metric_collector.go
+++ b/hystrix/metric_collector/metric_collector.go
@@ -53,6 +53,7 @@ type MetricResult struct {
 	ContextDeadlineExceeded float64
 	TotalDuration           time.Duration
 	RunDuration             time.Duration
+	ConcurrencyInUse        float64
 }
 
 // MetricCollector represents the contract that all collectors must fulfill to gather circuit statistics.

--- a/hystrix/metrics.go
+++ b/hystrix/metrics.go
@@ -9,9 +9,10 @@ import (
 )
 
 type commandExecution struct {
-	Types       []string      `json:"types"`
-	Start       time.Time     `json:"start_time"`
-	RunDuration time.Duration `json:"run_duration"`
+	Types            []string      `json:"types"`
+	Start            time.Time     `json:"start_time"`
+	RunDuration      time.Duration `json:"run_duration"`
+	ConcurrencyInUse float64       `json:"concurrency_inuse"`
 }
 
 type metricExchange struct {
@@ -68,9 +69,10 @@ func (m *metricExchange) Monitor() {
 func (m *metricExchange) IncrementMetrics(wg *sync.WaitGroup, collector metricCollector.MetricCollector, update *commandExecution, totalDuration time.Duration) {
 	// granular metrics
 	r := metricCollector.MetricResult{
-		Attempts:      1,
-		TotalDuration: totalDuration,
-		RunDuration:   update.RunDuration,
+		Attempts:         1,
+		TotalDuration:    totalDuration,
+		RunDuration:      update.RunDuration,
+		ConcurrencyInUse: update.ConcurrencyInUse,
 	}
 
 	switch update.Types[0] {


### PR DESCRIPTION
Adds a metric to access circuit concurrency utilization. It is calculated by
dividing active circuit tickets divided by max circuit tickets.