### PR TITLE
fix "Hystrix Dashboard" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ You can also use ```hystrix.Configure()``` which accepts a ```map[string]Command
 
 ### Enable dashboard metrics
 
-In your main.go, register the event stream HTTP handler on a port and launch it in a goroutine.  Once you configure turbine for your [Hystrix Dashboard](https://github.com/Netflix/Hystrix/tree/master/hystrix-dashboard) to start streaming events, your commands will automatically begin appearing.
+In your main.go, register the event stream HTTP handler on a port and launch it in a goroutine.  Once you configure turbine for your [Hystrix Dashboard](https://github.com/Netflix-Skunkworks/hystrix-dashboard) to start streaming events, your commands will automatically begin appearing.
 
 ```go
 hystrixStreamHandler := hystrix.NewStreamHandler()


### PR DESCRIPTION
> The hystrix-dashboard component of this project has been deprecated and moved to Netflix-Skunkworks/hystrix-dashboard.
https://github.com/Netflix/Hystrix/blob/master/README.md#dashboard