### PR TITLE
Adding MaxConcurrency to statsd metric reporting

### DIFF
--- a/hystrix/metric_collector/metric_collector.go
+++ b/hystrix/metric_collector/metric_collector.go
@@ -54,6 +54,7 @@ type MetricResult struct {
 	TotalDuration           time.Duration
 	RunDuration             time.Duration
 	ConcurrencyInUse        float64
+	MaxConcurrency		  	int
 }
 
 // MetricCollector represents the contract that all collectors must fulfill to gather circuit statistics.

--- a/hystrix/metrics.go
+++ b/hystrix/metrics.go
@@ -73,6 +73,7 @@ func (m *metricExchange) IncrementMetrics(wg *sync.WaitGroup, collector metricCo
 		TotalDuration:    totalDuration,
 		RunDuration:      update.RunDuration,
 		ConcurrencyInUse: update.ConcurrencyInUse,
+		MaxConcurrency:	  getSettings(m.Name).MaxConcurrentRequests,
 	}
 
 	switch update.Types[0] {

--- a/plugins/statsd_collector.go
+++ b/plugins/statsd_collector.go
@@ -30,6 +30,7 @@ type StatsdCollector struct {
 	deadlinePrefix          string
 	totalDurationPrefix     string
 	runDurationPrefix       string
+	maxConcurrencyPrefix	string
 	concurrencyInUsePrefix  string
 	sampleRate              float32
 }
@@ -111,6 +112,7 @@ func (s *StatsdCollectorClient) NewStatsdCollector(name string) metricCollector.
 		totalDurationPrefix:     name + ".totalDuration",
 		runDurationPrefix:       name + ".runDuration",
 		concurrencyInUsePrefix:  name + ".concurrencyInUse",
+		maxConcurrencyPrefix:	 name + ".maxConcurrency",
 		sampleRate:              s.sampleRate,
 	}
 }
@@ -167,6 +169,7 @@ func (g *StatsdCollector) Update(r metricCollector.MetricResult) {
 	g.updateTimerMetric(g.totalDurationPrefix, r.TotalDuration)
 	g.updateTimerMetric(g.runDurationPrefix, r.RunDuration)
 	g.updateTimingMetric(g.concurrencyInUsePrefix, int64(100*r.ConcurrencyInUse))
+	g.setGauge(g.maxConcurrencyPrefix, int64(r.MaxConcurrency))
 }
 
 // Reset is a noop operation in this collector.


### PR DESCRIPTION
Hi,
This value will be used to create graph with upper bond shows max concurrent configured vis the current concurrency. This graph will be useful to monitor/fine tune the allowed concurrency config.

Thanks for creating hystrix-go.