### PR TITLE
hystrix: wrap original err before returning from tryFallback

### DIFF
--- a/hystrix/hystrix.go
+++ b/hystrix/hystrix.go
@@ -290,7 +290,7 @@ func (c *command) tryFallback(ctx context.Context, err error) error {
 	fallbackErr := c.fallback(ctx, err)
 	if fallbackErr != nil {
 		c.reportEvent("fallback-failure")
-		return fmt.Errorf("fallback failed with '%v'. run error was '%v'", fallbackErr, err)
+		return fmt.Errorf("fallback failed with '%v'. run error was '%w'", fallbackErr, err)
 	}
 
 	c.reportEvent("fallback-success")


### PR DESCRIPTION
This will allow assertion on the error type (example: `errors.Is(err, hystrix.ErrTimeout)`) instead of doing substring matching from the errors returned after trying fallback